### PR TITLE
Use SHA version of GeoTrellis from Bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,11 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/
 
-before_install:
-  - mkdir -p ${HOME}/.sbt
-  - git clone https://github.com/geotrellis/geotrellis.git /tmp/geotrellis
-  - pushd /tmp/geotrellis
-  - git checkout cb236ac
-  - docker run --rm -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/geotrellis -w /geotrellis quay.io/azavea/scala:latest ./publish-local.sh
-  - popd
-
 script:
   - /bin/true
 
 before_deploy:
+  - mkdir -p ${HOME}/.sbt
   - docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/mmw-geoprocessing -w /mmw-geoprocessing quay.io/azavea/scala:latest ./sbt assembly
   - sudo chown ${USER} summary/target/scala-2.10/mmw-geoprocessing-assembly-${TRAVIS_TAG}.jar
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -10,7 +10,7 @@ object Version {
   def either(environmentVariable: String, default: String): String =
     Properties.envOrElse(environmentVariable, default)
 
-  val geotrellis   = "0.10.0-SNAPSHOT"
+  val geotrellis   = "0.10.0-cb236ac"
   val scala        = "2.10.5"
   val scalatest    = "2.2.1"
   lazy val jobserver = either("SPARK_JOBSERVER_VERSION", "0.5.1")
@@ -50,7 +50,9 @@ object Geoprocessing extends Build {
   )
 
   val resolutionRepos = Seq(
-    "Job Server Bintray" at "https://dl.bintray.com/spark-jobserver/maven"
+    Resolver.bintrayRepo("azavea", "geotrellis"),
+    Resolver.bintrayRepo("scalaz", "releases"),
+    "OpenGeo" at "http://repo.boundlessgeo.com/main"
   )
 
   val defaultAssemblySettings =


### PR DESCRIPTION
The JARs for SHA `cb236ac` are now published on Bintray, so after adding the `azavea/geotrellis` repository to this project's `build.scala`, the GeoTrellis dependencies resolve from Bintray vs. the local Ivy cache.

/cc @jwalgran
