### PR TITLE
BigTIFF translation program.

### DIFF
--- a/extra/bigtiff_translation/.gitignore
+++ b/extra/bigtiff_translation/.gitignore
@@ -1,0 +1,5 @@
+*.o
+*.tiff
+*.tif
+*.csv
+bt

--- a/extra/bigtiff_translation/Makefile
+++ b/extra/bigtiff_translation/Makefile
@@ -1,0 +1,19 @@
+CC = gcc
+CFLAGS = -O -std=c99
+OBJ = main.o checks.o
+
+.PHONY: all clean cleaner
+
+all : bt
+
+bt : $(OBJ)
+	$(CC) $(LDFLAGS) $(OBJ) -o bt
+
+%.o : %.c *.h
+	$(CC) $(CFLAGS) -c $*.c -o $@
+
+clean :
+	rm -f $(OBJ)
+
+cleaner : clean
+	rm -f bt

--- a/extra/bigtiff_translation/checks.c
+++ b/extra/bigtiff_translation/checks.c
@@ -1,0 +1,111 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "tiff.h"
+
+#define LITTLE_ENDIAN (0x4949)
+#define MAGIC_NUMBER (0x002b)
+#define BITS_PER_SAMPLE (0x0102)
+#define COMPRESSION (0x0103)
+#define SAMPLES_PER_PIXEL (0x0115)
+#define DATA_TYPE (0x0153)
+#define PLANAR_FORMAT (0x011c)
+#define TILE_OFFSETS (0x0144)
+#define TILE_LENGTHS (0x0145)
+
+
+void header_check(const bigtiff_header * header)
+{
+  if ((header->version != MAGIC_NUMBER) || (header->unused != 0x0000))
+    {
+      fprintf(stderr, "Bad format.\n");
+      exit(-1);
+    }
+  else if (header->order != LITTLE_ENDIAN)
+    {
+      fprintf(stderr, "Little-endian files only.\n");
+      exit(-1);
+    }
+  else if ((header->offset_length != sizeof(uint64_t)) || (sizeof(uint64_t) != 8))
+    {
+      fprintf(stderr, "Afraid to proceed.\n");
+      exit(-1);
+    }
+}
+
+void ifd_check(const bigtiff_header * header)
+{
+  uint64_t ifd_offset = 0;
+  uint64_t tag_count = 0;
+  uint64_t tag_table_offset = 0;
+  void * base_ptr = (void *)header;
+
+  ifd_offset = header->first_ifd;
+  tag_count = *(uint64_t *)(base_ptr + ifd_offset);
+  tag_table_offset = ifd_offset + sizeof(uint64_t);
+  if (*(uint64_t *)(base_ptr + tag_table_offset + sizeof(bigtiff_tag) * tag_count))
+    {
+      fprintf(stderr, "Only know how to handle one IFD.\n");
+      exit(-1);
+    }
+}
+
+void format_check(const bigtiff_tag * table, uint64_t table_size)
+{
+  for (int i = 0; i < table_size; ++i)
+    {
+      uint64_t data = table[i].data;
+
+      switch(table[i].tag_code) {
+      case BITS_PER_SAMPLE:
+        if (data != 32)
+          {
+            fprintf(stderr, "Expecting 32 bits/sample, found %d.\n", (int)data);
+            exit(-1);
+          }
+        break;
+      case COMPRESSION:
+        if (data != 1)
+          {
+            fprintf(stderr, "Expecting no compression.\n");
+            exit(-1);
+          }
+        break;
+      case SAMPLES_PER_PIXEL:
+        if (data != 1)
+          {
+            fprintf(stderr, "Expecting 1 sample/pixel, found %d.\n", (int)data);
+            exit(-1);
+          }
+        break;
+      case DATA_TYPE:
+	if (data != 1)
+	  {
+	    fprintf(stderr, "Expecting unsigned integer data.\n");
+	    exit(-1);
+	  }
+        break;
+      case PLANAR_FORMAT:
+	if (data != 1)
+	  {
+	    fprintf(stderr, "Expecting chunky planar format.\n");
+	    exit(-1);
+	  }
+      default:
+        break;
+      }
+    }
+}
+
+void get_tile_info(const bigtiff_tag * table, uint64_t table_size, uint64_t * tile_count, uint64_t * offsets, uint64_t * lengths)
+{
+  for (int i = 0; i < table_size; ++i)
+    {
+      if (table[i].tag_code == TILE_OFFSETS)
+	{
+	  *tile_count = table[i].number;
+	  *offsets = table[i].data;
+	}
+      else if (table[i].tag_code == TILE_LENGTHS)
+	*lengths = table[i].data;
+    }
+}

--- a/extra/bigtiff_translation/checks.h
+++ b/extra/bigtiff_translation/checks.h
@@ -1,0 +1,11 @@
+#ifndef __CHECKS_H__
+#define __CHECKS_H__
+
+#include "tiff.h"
+
+void header_check(const bigtiff_header *);
+void ifd_check(const bigtiff_header *);
+void format_check(const bigtiff_tag *, uint64_t);
+void get_tile_info(const bigtiff_tag *, uint64_t, uint64_t *, uint64_t *, uint64_t *);
+
+#endif

--- a/extra/bigtiff_translation/main.c
+++ b/extra/bigtiff_translation/main.c
@@ -1,0 +1,161 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include "tiff.h"
+#include "checks.h"
+
+
+/* mapping */
+typedef enum { UNKNOWN, A, B, C, D, AD, BD, CD } soil_type;
+#define MAPPINGS (0x400000)
+
+
+void load_mapping(const char * filename, soil_type * mapping)
+{
+  char soil_type[0x0f];
+  FILE * fp = NULL;
+
+  /* prepare to load mapping from CSV file */
+  fp = fopen(filename, "r");
+  fscanf(fp, "%s\n", soil_type);
+
+  /* load mapping from CSV file */
+  for (int values = 0, unwanted = 0, mukey = 0; values != EOF;)
+    {
+      values = fscanf(fp, "%d,%[ABCD/],%d\n", &unwanted, soil_type, &mukey);
+
+      if (values != 3)
+	{
+	  fscanf(fp, "%s\n", soil_type);
+	  continue;
+	}
+
+      if (!strcmp(soil_type, "A"))
+	mapping[mukey] = A;
+      else if (!strcmp(soil_type, "B"))
+	mapping[mukey] = B;
+      else if (!strcmp(soil_type, "C"))
+	mapping[mukey] = C;
+      else if (!strcmp(soil_type, "D"))
+	mapping[mukey] = D;
+      else if (!strcmp(soil_type, "A/B"))
+	mapping[mukey] = AD;
+      else if (!strcmp(soil_type, "B/D"))
+	mapping[mukey] = BD;
+      else if (!strcmp(soil_type, "C/D"))
+	mapping[mukey] = CD;
+    }
+
+  fclose(fp);
+}
+
+void map_file(const char * filename, void ** base_ptr, struct stat * info)
+{
+  int fd = open(filename, O_RDWR);
+
+  if (fd < 0)
+    {
+      fprintf(stderr, "Unable to open %s in read/write mode.\n", filename);
+      exit(-1);
+    }
+
+  fstat(fd, info);
+  *base_ptr = mmap(NULL, info->st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  close(fd);
+}
+
+void unmap_file(void * base_ptr, struct stat * info)
+{
+  msync(base_ptr, info->st_size, MS_SYNC);
+  munmap(base_ptr, info->st_size);
+}
+
+int main(int argc, char ** argv)
+{
+  soil_type * mapping;
+  void * base_ptr;
+  struct stat info;
+  bigtiff_header * header;
+  bigtiff_tag * tag_table;
+  uint64_t ifd_offset;
+  uint64_t tag_count;
+  uint64_t tile_count;
+  uint64_t offsets_offset;
+  uint64_t lengths_offset;
+  uint64_t * offsets = NULL;
+  uint64_t * lengths = NULL;
+
+  /* check arguments */
+  if (argc != 3)
+    {
+      fprintf(stderr, "usage: %s <tiff> <translation table>\n", argv[0]);
+      exit(-1);
+    }
+
+  /* load the mukey -> soil mapping */
+  mapping = calloc(MAPPINGS, sizeof(soil_type));
+  load_mapping(argv[2], mapping);
+
+  /* map the source tiff into memory */
+  map_file(argv[1], &base_ptr, &info);
+
+  /* check out the header */
+  header = base_ptr;
+  header_check(base_ptr);
+  ifd_check(base_ptr);
+
+  /* check the format of the file */
+  ifd_offset = header->first_ifd;
+  tag_count = *(uint64_t *)(base_ptr + ifd_offset);
+  tag_table = base_ptr + ifd_offset + sizeof(uint64_t);
+  format_check(tag_table, tag_count);
+
+  /* get numbers of tiles, their locations and lengths */
+  get_tile_info(tag_table, tag_count, &tile_count, &offsets_offset, &lengths_offset);
+  fprintf(stdout, "%llu 0x%016llx 0x%016llx\n",
+	  (long long int)tile_count,
+	  (long long unsigned)offsets_offset,
+	  (long long unsigned)lengths_offset);
+
+  offsets = base_ptr + offsets_offset;
+  lengths = base_ptr + lengths_offset;
+
+  /* for every tile ... */
+  for (int i = 0; i < tile_count; ++i)
+    {
+      uint32_t * tile = base_ptr + offsets[i];
+      unsigned int length = lengths[i] / sizeof(uint32_t);
+
+      if (!(i % (tile_count / 1000)))
+	{
+	  msync(base_ptr, info.st_size, MS_ASYNC);
+	  fprintf(stdout, "%d ", i);
+	  fflush(stdout);
+	}
+
+      /* ... and for every 32-bit word in the tile ... */
+      for (int j = 0; j < length; ++j)
+      	{
+	  /* ... translate the word.  The 16-slot gap at the beginning
+	     of the range is to (hopefully) allow the program to be
+	     restarted on a partially-converted raster. */
+	  if ((tile[j] > 0x0f) && (tile[j] < MAPPINGS))
+	    tile[j] = mapping[tile[j]];
+	  else
+	    tile[j] = 0;
+      	}
+    }
+  fprintf(stdout, "\n");
+
+  /* clean */
+  free(mapping);
+  unmap_file(base_ptr, &info);
+
+  /* return */
+  return 0;
+}

--- a/extra/bigtiff_translation/tiff.h
+++ b/extra/bigtiff_translation/tiff.h
@@ -1,0 +1,23 @@
+#ifndef __TIFF_H__
+#define __TIFF_H__
+
+#include <stdint.h>
+
+typedef struct
+{
+  uint16_t order;
+  uint16_t version;
+  uint16_t offset_length;
+  uint16_t unused;
+  uint64_t first_ifd;
+} __attribute__((packed)) bigtiff_header;
+
+typedef struct
+{
+  uint16_t tag_code;
+  uint16_t datatype;
+  uint64_t number;
+  uint64_t data;
+} __attribute__((packed)) bigtiff_tag;
+
+#endif


### PR DESCRIPTION
This program translates values in an uncompressed BigTIFF file.  It was created to translate mukey values in the gSSURGO dataset into small, useful numbers.

Do not attempt to use this program on anyting other than a 64-bit little-endian host.

Connects WikiWatershed/tr-55#42
