### PR TITLE
Update OpenGeo repository endpoint for GDAL dependency

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -52,7 +52,7 @@ object Geoprocessing extends Build {
   val resolutionRepos = Seq(
     Resolver.bintrayRepo("azavea", "geotrellis"),
     Resolver.bintrayRepo("scalaz", "releases"),
-    "OpenGeo" at "http://repo.boundlessgeo.com/main"
+    "OpenGeo" at "https://boundless.artifactoryonline.com/boundless/main"
   )
 
   val defaultAssemblySettings =


### PR DESCRIPTION
The previous OpenGeo repository endpoint redirect to the one referenced now, but `sbt` does not appear to follow the redirect. In order to get things working, I just replaced the repository endpoint with the redirect destination.

---

**Testing**

In order to test, remove your local Ivy cache (`~/.ivy2`) and attempt to execute the project test suite:

``` bash
$ ./sbt test
```
