### PR TITLE
Make soil type 'C' the default for missing values

### DIFF
--- a/summary/src/main/scala/SummaryJob.scala
+++ b/summary/src/main/scala/SummaryJob.scala
@@ -148,7 +148,7 @@ object SummaryJob extends SparkJob {
                 def apply(col: Int, row: Int): Unit = {
                   val nlcdType = nlcdTile.get(col,row)
                   val soilType = soilTile.get(col,row) match {
-                    case -2147483648 => 2
+                    case -2147483648 => 3
                     case n : Int => n
                   }
                   val pair = (nlcdType, soilType)

--- a/summary/src/main/scala/SummaryJob.scala
+++ b/summary/src/main/scala/SummaryJob.scala
@@ -94,23 +94,6 @@ object SummaryJob extends SparkJob {
     import geotrellis.spark.io.Intersects
 
       layerId match {
-    //   // If the user asked for fake soil data, then some special steps
-    //   // must be taken to synthesize that from nlcd-wm-ext-tms layer.
-    //   case LayerId("soil-fake", zoom) => {
-    //     val newLayerId = LayerId("nlcd-wm-ext-tms", zoom)
-    //     var z : Int = 0
-    //     catalog.query[SpatialKey](newLayerId)
-    //       .where(Intersects(extent))
-    //       .toRDD
-    //       .localMap { y: Int => {
-    //         val a = 8121
-    //         val c = 28411
-    //         val m = 134456
-    //         z = ((a * (z + y) * (z + y) + c) % m)
-    //         (Math.abs(z) % 4) + 1
-    //       }
-    //     }
-    //   }
       // If the user asked for anything else, give them exactly what they asked for.
       case layerId : LayerId => {
         catalog.query(layerId)


### PR DESCRIPTION
Number to soil type mapping is available here: https://github.com/WikiWatershed/model-my-watershed/blob/develop/src/mmw/apps/modeling/geoprocessing.py#L38-L52

``` python
# The soil rasters contain the numbers 1 through 7 (the keys of this
# dictionary).  The values of this dictionary are length-two arrays
# containing two strings.  The first member of each array is the name
# used for the corresponding soil-type in the TR-55 code.  The second
# member of each array is a human-readable description of that
# soil-type.
SOIL_MAPPING = {
    1: ['a', 'A - High Infiltration'],
    2: ['b', 'B - Moderate Infiltration'],
    3: ['c', 'C - Slow Infiltration'],
    4: ['d', 'D - Very Slow Infiltration'],
    5: ['ad', 'A/D - High/Very Slow Infiltration'],
    6: ['bd', 'B/D - Medium/Very Slow Infiltration'],
    7: ['cd', 'C/D - Medium/Very Slow Infiltration']
}
```

Connects https://github.com/WikiWatershed/model-my-watershed/issues/1015
