### PR TITLE
Update Geotrellis Version to 0.10.0-177004b

### DIFF
--- a/examples/request.json
+++ b/examples/request.json
@@ -5,8 +5,8 @@
         ],
         "tileCRS": "ConusAlbers",
         "polyCRS": "LatLng",
-        "nlcdLayer": "nlcd-10m-epsg5070",
-        "soilLayer": "ssurgo-soil-groups-10m",
+        "nlcdLayer": "nlcd-2011-30m-epsg5070",
+        "soilLayer": "ssurgo-hydro-groups-30m-epsg5070",
         "zoom": 0
     }
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -10,7 +10,7 @@ object Version {
   def either(environmentVariable: String, default: String): String =
     Properties.envOrElse(environmentVariable, default)
 
-  val geotrellis   = "0.10.0-97834e6"
+  val geotrellis   = "0.10.0-177004b"
   val scala        = "2.10.5"
   val scalatest    = "2.2.1"
   lazy val jobserver = either("SPARK_JOBSERVER_VERSION", "0.5.1")


### PR DESCRIPTION
Some incompatible changes to the S3LayerReader interface were introduced sometime around Geotrellis version 2d2bdde.

The present commit updates the code to be compilable with newer versions of Geotrellis.

Limited testing shows that these changes produce the same results as before.  Since the polygon rasterizer in Geotrellis has been replaced with a (hopefully) more correct implementation, the possibility of differences is not inconceivable. 

Connects #19
### To Test
1. Pull down this branch
2. Build the code './sbt assembly'
3. Copy the jar to the worker VM `scp ./summary/target/scala-2.10/mmw-geoprocessing-assembly-0.3.2.jar vagrant@33.33.34.20:`
4. ssh into the worker VM `vagrant ssh worker` or `ssh vagrant@33.33.34.20`
5. Overwrite the existing geoprocessing jar, `/opt/geoprocessing/mmw-geoprocessing-0.3.2.jar`, with the new one.
6. Reload the worker VM
