### PR TITLE
Update dependency version defaults (Spark, SJS, Scala)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 
 before_deploy:
   - mkdir -p ${HOME}/.sbt
-  - docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/mmw-geoprocessing -w /mmw-geoprocessing quay.io/azavea/scala:latest ./sbt assembly
+  - docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/mmw-geoprocessing -w /mmw-geoprocessing quay.io/azavea/scala:2.10.5 ./sbt assembly
   - sudo chown ${USER} summary/target/scala-2.10/mmw-geoprocessing-assembly-${TRAVIS_TAG}.jar
 
 deploy:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ docker run \
     --volume ${HOME}/.ivy2:/root/.ivy2 \
     --volume ${PWD}:/mmw-geoprocessing \
     --workdir /mmw-geoprocessing \
-    quay.io/azavea/scala:latest ./sbt assembly
+    quay.io/azavea/scala:2.10.5 ./sbt assembly
 ```
 
 Next, use the latest Spark Job Server (SJS) Docker image to launch an instance of SJS locally:
@@ -33,7 +33,7 @@ $ docker run \
     --volume ${PWD}/examples/conf/spark-jobserver.conf:/opt/spark-jobserver/spark-jobserver.conf:ro \
     --publish 8090:8090 \
     --name spark-jobserver \
-    quay.io/azavea/spark-jobserver:latest
+    quay.io/azavea/spark-jobserver:0.6.1
 ```
 
 **Note**: Ensure that the `default` credentials in your `$HOME/.aws/credentials` file is set with the appropriate AWS API keys. Otherwise, you may have to set the `AWS_PROFILE` environment variable to your custom credential profile.

--- a/project/build.scala
+++ b/project/build.scala
@@ -11,11 +11,11 @@ object Version {
     Properties.envOrElse(environmentVariable, default)
 
   val geotrellis   = "0.10.0-177004b"
-  val scala        = "2.10.5"
+  val scala        = either("SCALA_VERSION", "2.10.5")
   val scalatest    = "2.2.1"
-  lazy val jobserver = either("SPARK_JOBSERVER_VERSION", "0.5.1")
+  lazy val jobserver = either("SPARK_JOBSERVER_VERSION", "0.6.1")
   lazy val hadoop  = either("SPARK_HADOOP_VERSION", "2.6.0")
-  lazy val spark   = either("SPARK_VERSION", "1.3.1")
+  lazy val spark   = either("SPARK_VERSION", "1.5.2")
 }
 
 object Geoprocessing extends Build {


### PR DESCRIPTION
Bump dependency versions for:
- Scala (2.10.5)
- Spark (1.5.2)
- Spark Job Server (0.6.1)
