### PR TITLE
MapShed Job Stub

### DIFF
--- a/summary/src/main/scala/JobUtils.scala
+++ b/summary/src/main/scala/JobUtils.scala
@@ -1,0 +1,89 @@
+package org.wikiwatershed.mmw.geoprocessing
+
+import geotrellis.raster._
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.io.s3._
+import geotrellis.vector._
+import geotrellis.vector.io._
+
+import com.typesafe.config.Config
+import org.apache.spark.SparkContext
+
+/**
+  * Collection of common utilities to be used by SparkJobs
+  */
+trait JobUtils {
+  /**
+    * Transform the incoming GeoJSON into a [[MultiPolygon]] in the
+    * destination CRS.
+    *
+    * @param   geoJson  The incoming geometry
+    * @param   srcCRS   The CRS that the incoming geometry is in
+    * @param   destCRS  The CRS that the outgoing geometry should be in
+    * @return           A MultiPolygon
+    */
+  def parseGeometry(geoJson: String, srcCRS: geotrellis.proj4.CRS, destCRS: geotrellis.proj4.CRS): MultiPolygon = {
+    import spray.json._
+
+    geoJson.parseJson.convertTo[Geometry] match {
+      case p: Polygon => MultiPolygon(p.reproject(srcCRS, destCRS))
+      case mp: MultiPolygon => mp.reproject(srcCRS, destCRS)
+      case _ => MultiPolygon()
+    }
+  }
+
+  /**
+    * Fetch a particular layer from the catalog, restricted to the
+    * given extent, and return a [[TileLayerRDD]] of the result.
+    *
+    * @param   catalog  The S3 location from which the data should be read
+    * @param   layerId  The layer that should be read
+    * @param   extent   The extent (subset) of the layer that should be read
+    * @return           An RDD of [[SpatialKey]]s
+    */
+  def queryAndCropLayer(catalog: S3LayerReader, layerId: LayerId, extent: Extent): TileLayerRDD[SpatialKey] = {
+    catalog.query[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](layerId)
+      .where(Intersects(extent))
+      .result
+  }
+
+  /**
+    * Return an [[S3LayerReader]] object to read from the catalog
+    * directory in the azavea datahub.
+    *
+    * @return  An S3LayerReader object
+    */
+  def catalog(sc: SparkContext): S3LayerReader =
+    catalog("azavea-datahub", "catalog")(sc)
+
+  /**
+    * Take a bucket and a catalog, and return an [[S3LayerReader]]
+    * object to read from it.
+    *
+    * @param   bucket    The name of the S3 bucket
+    * @param   rootPath  The name of the catalog (child of the root directory) in the bucket
+    * @return            An S3LayerReader object
+    */
+  def catalog(bucket: String, rootPath: String)(implicit sc: SparkContext): S3LayerReader = {
+    val attributeStore = new S3AttributeStore(bucket, rootPath)
+    val catalog = new S3LayerReader(attributeStore)
+
+    catalog
+  }
+
+  /**
+    * For a given config, return a function that can find the value of a key
+    * if it exists in the config.
+    *
+    * @param   config    The config containing keys
+    * @return            A function String => Option[String] that takes a key
+    *                    and returns its value if it exists, else None
+    */
+  def getOptionalFn(config: Config) = (key: String) => {
+    config.hasPath(key) match {
+      case true => Option(config.getString(key))
+      case false => None
+    }
+  }
+}

--- a/summary/src/main/scala/MapshedJob.scala
+++ b/summary/src/main/scala/MapshedJob.scala
@@ -1,0 +1,105 @@
+package org.wikiwatershed.mmw.geoprocessing
+
+import geotrellis.spark.{LayerId, SpatialKey, TileLayerRDD}
+import geotrellis.vector.{GeometryCollection, MultiPolygon, MultiPolygonResult, Polygon, PolygonResult}
+import com.typesafe.config.Config
+import geotrellis.raster.rasterize.{Callback, Rasterizer}
+import org.apache.spark.SparkContext
+import spark.jobserver.{SparkJob, SparkJobValid, SparkJobValidation}
+
+
+case class MapshedJobParams(nlcdLayerId: LayerId, geometry: Seq[MultiPolygon])
+
+object MapshedJob extends SparkJob with JobUtils {
+  override def validate(sc: SparkContext, config: Config): SparkJobValidation = {
+    // TODO Add real validation
+    SparkJobValid
+  }
+
+  override def runJob(sc: SparkContext, config: Config): Any = {
+    val params = parseConfig(config)
+    val extent = GeometryCollection(params.geometry).envelope
+    val nlcdLayer = queryAndCropLayer(catalog(sc), params.nlcdLayerId, extent)
+
+    histogram(nlcdLayer, params.geometry)
+  }
+
+  def parseConfig(config: Config): MapshedJobParams = {
+    import scala.collection.JavaConverters._
+    import geotrellis.proj4.{LatLng, WebMercator}
+
+    val getOptional = getOptionalFn(config)
+
+    val zoom = config.getInt("input.zoom")
+    val nlcdLayer = LayerId(config.getString("input.nlcdLayer"), zoom)
+
+    val tileCRS = getOptional("input.tileCRS") match {
+      case Some("LatLng") => LatLng
+      case Some("WebMercator") => WebMercator
+      case Some("ConsuAlbers") => ConusAlbers
+      case _ => ConusAlbers
+    }
+    val polyCRS = getOptional("input.polyCRS") match {
+      case Some("LatLng") => LatLng
+      case Some("WebMercator") => WebMercator
+      case Some("ConusAlbers") => ConusAlbers
+      case _ => LatLng
+    }
+
+    val geometry = config.getStringList("input.geometry").asScala.map {
+      str => parseGeometry(str, polyCRS, tileCRS)
+    }
+
+    MapshedJobParams(nlcdLayer, geometry)
+  }
+
+  def histogram(layer: TileLayerRDD[SpatialKey], multiPolygons: Seq[MultiPolygon]) = {
+    import scala.collection.mutable
+    import geotrellis.raster.RasterExtent
+
+    val histogramParts = layer.map { case (key, tile) =>
+      multiPolygons.map { multiPolygon =>
+        val extent = layer.metadata.mapTransform(key) // transform spatial key to extent
+        val rasterExtent = RasterExtent(extent, tile.cols, tile.rows) // transform extent to raster extent
+        val clipped = multiPolygon & extent
+        val localHistogram = mutable.Map.empty[Int, Int]
+
+        def intersectionComponentsToHistogram(ps: Seq[Polygon]) = {
+          ps.foreach { p =>
+            Rasterizer.foreachCellByPolygon(p, rasterExtent)(
+              new Callback {
+                def apply(col: Int, row: Int): Unit = {
+                  val nlcdType = tile.get(col, row)
+
+                  if (!localHistogram.contains(nlcdType)) {
+                    localHistogram(nlcdType) = 0
+                  }
+
+                  localHistogram(nlcdType) += 1
+                }
+              }
+            )
+          }
+        }
+
+        clipped match {
+          case PolygonResult(p) => intersectionComponentsToHistogram(List(p))
+          case MultiPolygonResult(mp) => intersectionComponentsToHistogram(mp.polygons)
+          case _ =>
+        }
+
+        localHistogram.toMap
+      }
+    }
+
+    histogramParts.reduce { (s1, s2) =>
+      (s1 zip s2).map { case (left, right) =>
+        (left.toSeq ++ right.toSeq)
+          .groupBy(_._1)
+          .map { case (nlcdType, counts) =>
+            (nlcdType, counts.map(_._2).sum)
+          }
+      }
+    }
+  }
+}

--- a/summary/src/main/scala/SummaryJob.scala
+++ b/summary/src/main/scala/SummaryJob.scala
@@ -2,10 +2,7 @@ package org.wikiwatershed.mmw.geoprocessing
 
 import geotrellis.raster._
 import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.spark.io.s3._
 import geotrellis.vector._
-import geotrellis.vector.io._
 
 import com.typesafe.config.Config
 import org.apache.spark._
@@ -20,7 +17,7 @@ case class SummaryJobParams(nlcdLayerId: LayerId, soilLayerId: LayerId, geometry
 /**
   * The "main" object for this module.
   */
-object SummaryJob extends SparkJob {
+object SummaryJob extends SparkJob with JobUtils {
 
   override def validate(sc: SparkContext, config: Config): SparkJobValidation = {
     SparkJobValid
@@ -49,12 +46,7 @@ object SummaryJob extends SparkJob {
     import scala.collection.JavaConverters._
     import geotrellis.proj4._
 
-    def getOptional(key : String) : Option[String] = {
-      config.hasPath(key) match {
-        case true => Option(config.getString(key))
-        case false => None
-      }
-    }
+    val getOptional = getOptionalFn(config)
 
     val zoom = config.getInt("input.zoom")
     val nlcdLayer = LayerId(config.getString("input.nlcdLayer"), zoom)
@@ -76,64 +68,6 @@ object SummaryJob extends SparkJob {
     }
 
     SummaryJobParams(nlcdLayer, soilLayer, geometry)
-  }
-
-  /**
-    * Transform the incoming GeoJSON into a [[MultiPolygon]] in the
-    * destination CRS.
-    *
-    * @param   geoJson  The incoming geometry
-    * @param   srcCRS   The CRS that the incoming geometry is in
-    * @param   destCRS  The CRS that the outgoing geometry should be in
-    * @return           A MultiPolygon
-    */
-  def parseGeometry(geoJson: String, srcCRS: geotrellis.proj4.CRS, destCRS: geotrellis.proj4.CRS) : MultiPolygon = {
-    import spray.json._
-
-    geoJson.parseJson.convertTo[Geometry] match {
-      case p: Polygon => MultiPolygon(p.reproject(srcCRS, destCRS))
-      case mp: MultiPolygon => mp.reproject(srcCRS, destCRS)
-      case _ => MultiPolygon()
-    }
-  }
-
-  /**
-    * Fetch a particular layer from the catalog, restricted to the
-    * given extent, and return a [[TileLayerRDD]] of the result.
-    *
-    * @param   catalog  The S3 location from which the data should be read
-    * @param   layerId  The layer that should be read
-    * @param   extent   The extent (subset) of the layer that should be read
-    * @return           An RDD of [[SpatialKey]]s
-    */
-  def queryAndCropLayer(catalog : S3LayerReader, layerId: LayerId, extent: Extent): TileLayerRDD[SpatialKey] = {
-      catalog.query[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](layerId)
-        .where(Intersects(extent))
-        .result
-  }
-
-  /**
-    * Return an [[S3LayerReader]] object to read from the catalog
-    * directory in the azavea datahub.
-    *
-    * @return  An S3LayerReader object
-    */
-  def catalog(sc: SparkContext): S3LayerReader =
-    catalog("azavea-datahub", "catalog")(sc)
-
-  /**
-    * Take a bucket and a catalog, and return an [[S3LayerReader]]
-    * object to read from it.
-    *
-    * @param   bucket    The name of the S3 bucket
-    * @param   rootPath  The name of the catalog (child of the root directory) in the bucket
-    * @return            An S3LayerReader object
-    */
-  def catalog(bucket: String, rootPath: String)(implicit sc: SparkContext): S3LayerReader = {
-    val attributeStore = new S3AttributeStore(bucket, rootPath)
-    val catalog = new S3LayerReader(attributeStore)
-
-    catalog
   }
 
   /**


### PR DESCRIPTION
## Overview

Extracts common functionality into a trait that can be mixed in with multiple Spark Job implementations. Adds a simple stub for a `MapshedJob` which currently simply returns the the count of cells grouped by their NLCD value for a given polygon.
## Testing Instructions
1. Package the code:
   
   ```
   ./sbt "project summary" assembly
   ```
2. Start the `worker` VM. Within the VM, rename `/opt/geoprocessing/mmw-geoprocessing-0.4.0.jar` to `/opt/geoprocessing/mmw-geoprocessing-0.4.0.jar.bak`
3. Copy the generated `summary/target/scala-2.10/mmw-geoprocessing-assembly-0.4.0.jar` file into the `worker` VM as `/opt/geoprocessing/mmw-geoprocessing-0.4.0.jar`
4. Copy the two test requests into your `worker` VM: [MapshedJob.json.txt](https://github.com/WikiWatershed/mmw-geoprocessing/files/208636/MapshedJob.json.txt) and [SummaryJob.json.txt](https://github.com/WikiWatershed/mmw-geoprocessing/files/208657/SummaryJob.json.txt)
5. Ensure that line 34 of `/opt/spark-jobserver/spark-jobserver.conf` reads `"geotrellis.spark.io.kryo.KryoRegistrator"`:
   
   ```
   vagrant@worker:~$ sed '34q;d' /opt/spark-jobserver/spark-jobserver.conf 
     context-settings.passthrough.spark.kryo.registrator = "geotrellis.spark.io.kryo.KryoRegistrator"
   ```
   
    This is needed for the newer version of GeoTrellis.
6. Restart Spark Job Server
   
   ```
   vagrant@worker:~$ sudo restart spark-jobserver
   spark-jobserver start/running, process 3245
   ```
7. Create a job context:
   
   ```
   vagrant@worker:~$ curl --silent --data '' 'http://localhost:8090/contexts/geoprocessing-context'
   OK
   ```
8. Test `MapshedJob`:
   
   ```
   vagrant@worker:~$ curl --silent --data-binary @MapshedJob.json.txt 'http://localhost:8090/jobs?sync=true&context=geoprocessing-context&appName=geoprocessing-0.4.0&classPath=org.wikiwatershed.mmw.geoprocessing.MapshedJob'
   {
     "result": [{
       "11": 11861,
       "90": 25355,
       "22": 31,
       "21": 1139,
       "43": 99663,
       "71": 2326,
       "31": 751,
       "95": 1534,
       "42": 54230,
       "41": 77316,
       "52": 25967
     }]
   }
   ```
9. Test `SummaryJob` to ensure it still works correctly:
   
   ```
   vagrant@worker:~$ curl --silent --data-binary @SummaryJob.json.txt 'http://localhost:8090/jobs?sync=true&context=geoprocessing-context&appName=geoprocessing-0.4.0&classPath=org.wikiwatershed.mmw.geoprocessing.SummaryJob'
   {
     "result": [{
       "(71,3)": 865,
       "(90,3)": 1650,
       "(22,7)": 5,
       "(11,1)": 104,
       "(11,6)": 10,
       "(52,3)": 7051,
       "(22,3)": 7,
       "(22,1)": 6,
       "(11,7)": 276,
       "(90,2)": 644,
       "(21,3)": 89,
       "(11,3)": 10998,
       "(31,7)": 208,
       "(52,6)": 40,
       "(52,2)": 1213,
       "(90,1)": 1901,
       "(43,4)": 40799,
       "(11,2)": 81,
       "(21,7)": 235,
       "(42,6)": 63,
       "(95,3)": 144,
       "(71,7)": 242,
       "(90,7)": 7473,
       "(71,1)": 207,
       "(95,2)": 8,
       "(52,7)": 5897,
       "(41,1)": 7486,
       "(22,4)": 13,
       "(41,7)": 10741,
       "(21,4)": 434,
       "(31,4)": 254,
       "(42,7)": 12392,
       "(43,3)": 21667,
       "(71,6)": 17,
       "(41,2)": 1826,
       "(52,1)": 2476,
       "(90,6)": 2324,
       "(21,2)": 19,
       "(95,7)": 471,
       "(42,4)": 30492,
       "(21,1)": 297,
       "(71,2)": 198,
       "(41,6)": 245,
       "(21,6)": 65,
       "(42,1)": 4790,
       "(43,6)": 380,
       "(43,7)": 19607,
       "(41,4)": 32622,
       "(52,4)": 9290,
       "(41,3)": 24396,
       "(71,4)": 797,
       "(42,3)": 4531,
       "(95,6)": 112,
       "(95,1)": 68,
       "(95,4)": 731,
       "(43,1)": 13473,
       "(90,4)": 11363,
       "(42,2)": 1962,
       "(11,4)": 392,
       "(31,2)": 93,
       "(31,3)": 100,
       "(31,1)": 96,
       "(43,2)": 3737
     }]
   }
   ```

Connects #25
