### PR TITLE
Fetch tiles intersecting shape, not bounding box

### DIFF
--- a/summary/src/main/scala/JobUtils.scala
+++ b/summary/src/main/scala/JobUtils.scala
@@ -60,18 +60,18 @@ trait JobUtils {
     * Fetch a particular layer from the catalog, restricted to the
     * given extent, and return a [[TileLayerRDD]] of the result.
     *
-    * @param   catalog  The S3 location from which the data should be read
-    * @param   layerId  The layer that should be read
-    * @param   extent   The extent (subset) of the layer that should be read
-    * @return           An RDD of [[SpatialKey]]s
+    * @param   catalog       The S3 location from which the data should be read
+    * @param   layerId       The layer that should be read
+    * @param   multiPolygon  The shape to crop the layer to
+    * @return                An RDD of [[SpatialKey]]s
     */
   def queryAndCropLayer(
     catalog: S3LayerReader,
     layerId: LayerId,
-    extent: Extent
+    multiPolygon: MultiPolygon
   ): TileLayerRDD[SpatialKey] = {
     catalog.query[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](layerId)
-      .where(Intersects(extent))
+      .where(Intersects(multiPolygon))
       .result
   }
 
@@ -235,16 +235,16 @@ trait JobUtils {
     * Set of methods for easy processing of parameters
     */
   def toLayers(rasterLayerIds: Seq[LayerId], polygon: Seq[MultiPolygon], sc: SparkContext) = {
-    val extent = GeometryCollection(polygon).envelope
+    val multiPolygon = polygon.unionGeometries.asMultiPolygon.get
     val rasterLayers = rasterLayerIds.map({ rasterLayerId =>
-      queryAndCropLayer(catalog(sc), rasterLayerId, extent)
+      queryAndCropLayer(catalog(sc), rasterLayerId, multiPolygon)
     })
 
     rasterLayers
   }
 
   def toLayers(rasterLayerIds: Seq[LayerId], targetLayerId: LayerId, polygon: Seq[MultiPolygon], sc: SparkContext) = {
-    val extent = GeometryCollection(polygon).envelope
+    val extent = polygon.unionGeometries.asMultiPolygon.get
     val rasterLayers = rasterLayerIds.map({ rasterLayerId =>
       queryAndCropLayer(catalog(sc), rasterLayerId, extent)
     })
@@ -254,8 +254,8 @@ trait JobUtils {
   }
 
   def toLayers(targetLayerId: LayerId, polygon: Seq[MultiPolygon], sc: SparkContext) = {
-    val extent = GeometryCollection(polygon).envelope
-    val targetLayer = queryAndCropLayer(catalog(sc), targetLayerId, extent)
+    val multiPolygon = polygon.unionGeometries.asMultiPolygon.get
+    val targetLayer = queryAndCropLayer(catalog(sc), targetLayerId, multiPolygon)
 
     targetLayer
   }

--- a/summary/src/main/scala/JobUtils.scala
+++ b/summary/src/main/scala/JobUtils.scala
@@ -58,7 +58,7 @@ trait JobUtils {
 
   /**
     * Fetch a particular layer from the catalog, restricted to the
-    * given extent, and return a [[TileLayerRDD]] of the result.
+    * given multiPolygon, and return a [[TileLayerRDD]] of the result.
     *
     * @param   catalog       The S3 location from which the data should be read
     * @param   layerId       The layer that should be read
@@ -244,11 +244,11 @@ trait JobUtils {
   }
 
   def toLayers(rasterLayerIds: Seq[LayerId], targetLayerId: LayerId, polygon: Seq[MultiPolygon], sc: SparkContext) = {
-    val extent = polygon.unionGeometries.asMultiPolygon.get
+    val multiPolygon = polygon.unionGeometries.asMultiPolygon.get
     val rasterLayers = rasterLayerIds.map({ rasterLayerId =>
-      queryAndCropLayer(catalog(sc), rasterLayerId, extent)
+      queryAndCropLayer(catalog(sc), rasterLayerId, multiPolygon)
     })
-    val targetLayer = queryAndCropLayer(catalog(sc), targetLayerId, extent)
+    val targetLayer = queryAndCropLayer(catalog(sc), targetLayerId, multiPolygon)
 
     (rasterLayers, targetLayer)
   }

--- a/summary/src/main/scala/SummaryJob.scala
+++ b/summary/src/main/scala/SummaryJob.scala
@@ -34,9 +34,9 @@ object SummaryJob extends SparkJob with JobUtils {
 
   override def runJob(sc: SparkContext, config: Config): Any = {
     val params = parseConfig(config)
-    val extent = GeometryCollection(params.geometry).envelope
-    val nlcdLayer = queryAndCropLayer(catalog(sc), params.nlcdLayerId, extent)
-    val soilLayer = queryAndCropLayer(catalog(sc), params.soilLayerId, extent)
+    val multiPolygon = params.geometry.unionGeometries.asMultiPolygon.get
+    val nlcdLayer = queryAndCropLayer(catalog(sc), params.nlcdLayerId, multiPolygon)
+    val soilLayer = queryAndCropLayer(catalog(sc), params.soilLayerId, multiPolygon)
 
     histograms(nlcdLayer, soilLayer, params.geometry)
   }


### PR DESCRIPTION
## Overview

Previously we would fetch all tiles from S3 that intersected with the bounding box of the incoming shape. This was wasteful, especially in cases where the shape was a long diagonal.

Now, by cropping to the multiPolygon resulting from unioning all incoming shapes, rather than calculating an envelope, we ensure that only relevant tiles are fetched.

Since fetching from S3 is a sizable portion of our latency, this change improves performance 10-20%.

Connects #41 

### Demo

Here's a table of runtimes in seconds with [nlcd-soils-request-huc8.json](https://github.com/WikiWatershed/mmw-geoprocessing/files/1022793/nlcd-soils-request-huc8.json.txt) which is a Soils + NLCD RasterGroupedCount operation (used for TR-55) with the Schuylkill HUC-08, and [nlcd-soils-request.json](https://github.com/WikiWatershed/mmw-geoprocessing/files/1022795/nlcd-soils-request.json.txt) which is the same request but with the Little Neshaminy HUC-12 instead:

| [nlcd-soils-request-huc8](https://github.com/WikiWatershed/mmw-geoprocessing/files/1022793/nlcd-soils-request-huc8.json.txt) | `develop` | `tt/waste-less-fetch-less` |
|-------------------------|--------:|-------------------------:|
| 1                       |   40.34 |                    36.52 |
| 2                       |   33.26 |                    25.58 |
| 3                       |   28.28 |                    20.19 |
| 4                       |   30.39 |                    21.08 |
| 5                       |    33.2 |                    24.36 |

![image](https://cloud.githubusercontent.com/assets/1430060/26363412/f620bdd6-3fae-11e7-9168-8250379e6d64.png)

| [nlcd-soils-request](https://github.com/WikiWatershed/mmw-geoprocessing/files/1022795/nlcd-soils-request.json.txt) | `develop` | `tt/waste-less-fetch-less` |
|--------------------|----------:|---------------------------:|
| 1                  |      5.22 |                       3.77 |
| 2                  |      4.45 |                        4.1 |
| 3                  |      4.05 |                       3.58 |
| 4                  |      4.26 |                       3.38 |
| 5                  |      4.72 |                       3.59 |

![image](https://cloud.githubusercontent.com/assets/1430060/26363495/32001f90-3faf-11e7-8140-5ae84e313c42.png)

## Testing Instructions

Tagging @echeipesh for quick code review.

 * Download [nlcd-soils-request-huc8.json](https://github.com/WikiWatershed/mmw-geoprocessing/files/1022793/nlcd-soils-request-huc8.json.txt) and [nlcd-soils-request.json](https://github.com/WikiWatershed/mmw-geoprocessing/files/1022795/nlcd-soils-request.json.txt), and use them as is, or replace the `polygon` with other shapes
 * Use the JSONs to develop a baseline:

    ```bash
    http --timeout=90 :8090/jobs sync==true timeout==90 context==geoprocessing appName==geoprocessing-1.2.0 classPath==org.wikiwatershed.mmw.geoprocessing.MapshedJob < nlcd-soils-request-huc8.json > nlcd-soils-response-huc8.json
    http --timeout=90 :8090/jobs sync==true timeout==90 context==geoprocessing appName==geoprocessing-1.2.0 classPath==org.wikiwatershed.mmw.geoprocessing.MapshedJob < nlcd-soils-request.json > nlcd-soils-response.json
    ```

 * Check out this branch, and build the geoprocessing service and load it into the worker (where `$MMW_GEOPROCESSING_DIR` is your local directory where you have checked out this repo, and `$MMW_DIR` is your local directory where you have checked out the main app):

    ```bash
    cd $MMW_GEOPROCESSING_DIR
    ./sbt "project summary" assembly
    mv -f summary/target/scala-2.10/mmw-geoprocessing-assembly-1.2.0.jar $MMW_DIR/src/mmw/
    cd $MMW_DIR
    vagrant ssh worker -c "sudo mv /opt/app/mmw-geoprocessing-assembly-1.2.0.jar /opt/geoprocessing/mmw-geoprocessing-1.2.0.jar && sudo service spark-jobserver restart"
    ```

 * Run the above requests again, and save their responses to new files:

    ```bash
    http --timeout=90 :8090/jobs sync==true timeout==90 context==geoprocessing appName==geoprocessing-1.2.0 classPath==org.wikiwatershed.mmw.geoprocessing.MapshedJob < nlcd-soils-request-huc8.json > nlcd-soils-response-huc8-new.json
    http --timeout=90 :8090/jobs sync==true timeout==90 context==geoprocessing appName==geoprocessing-1.2.0 classPath==org.wikiwatershed.mmw.geoprocessing.MapshedJob < nlcd-soils-request.json > nlcd-soils-response-new.json
    ```

 * Ensure that the original response and the `-new` responses have the same values
 * Try interacting with the main app. Notice if long, thin, diagonal shapes take less time than staging
