### PR TITLE
Update GeoTrellis catalog endpoint

### DIFF
--- a/summary/src/main/scala/JobUtils.scala
+++ b/summary/src/main/scala/JobUtils.scala
@@ -82,7 +82,7 @@ trait JobUtils {
     * @return  An S3LayerReader object
     */
   def catalog(sc: SparkContext): S3LayerReader =
-    catalog("azavea-datahub", "catalog")(sc)
+    catalog("datahub-catalogs-us-east-1", "")(sc)
 
   /**
     * Take a bucket and a catalog, and return an [[S3LayerReader]]


### PR DESCRIPTION
Update the configured GeoTrellis catalog endpoint used by Model My Watershed so that the Azavea Datahub catalog endpoint is used.

Connects https://github.com/WikiWatershed/model-my-watershed/issues/1955
Depends on https://github.com/azavea/azavea-data-hub/pull/49

---

**Testing**

Build a JAR from this branch using Docker or OpenJDK 7:

```bash
$ docker run \
    --rm \        
    --volume ${HOME}/.ivy2:/root/.ivy2 \
    --volume ${PWD}:/mmw-geoprocessing \
    --workdir /mmw-geoprocessing \
    openjdk:7 ./sbt assembly
```

Afterwards, copy it to the root of your MMW project directory:

```bash
$ cp summary/target/scala-2.10/mmw-geoprocessing-assembly-1.2.0.jar \
     ~/Projects/model-my-watershed
```

Then, spin up your MMW development environment and SSH into the worker. Once inside, copy the JAR into the location Spark Job Server wants it at, then restart the service:

```bash
vagrant@worker:~$ sudo cp /vagrant/mmw-geoprocessing-assembly-1.2.0.jar /opt/geoprocessing/mmw-geoprocessing-1.2.0.jar
vagrant@worker:~$ sudo restart spark-jobserver 
```

Finally, interact with the MMW UI to trigger any and all SJS related asynchronous tasks you know about.