### PR TITLE
Standardize incoming geometries

### DIFF
--- a/summary/src/main/scala/JobUtils.scala
+++ b/summary/src/main/scala/JobUtils.scala
@@ -202,7 +202,9 @@ trait JobUtils {
     val rasterCRS = crs("input.rasterCRS")
     val polygonCRS = crs("input.polygonCRS")
     val rasterLayerIds = config.getStringList("input.rasters").asScala.map({ str => LayerId(str, zoom) })
-    val polygon = config.getStringList("input.polygon").asScala.map({ str => parseGeometry(str, polygonCRS, rasterCRS) })
+    val polygon = config.getStringList("input.polygon").asScala.map({
+      str => parseGeometry(str, polygonCRS, rasterCRS).buffer(0).asMultiPolygon.get
+    })
 
     val targetLayerId: Option[LayerId] = {
       if (config.hasPath("input.targetRaster"))
@@ -225,7 +227,9 @@ trait JobUtils {
     val polygonCRS = crs("input.polygonCRS")
     val linesCRS = crs("input.vectorCRS")
     val rasterLayerIds = config.getStringList("input.rasters").asScala.map({ str => LayerId(str, zoom) })
-    val polygon = config.getStringList("input.polygon").asScala.map({ str => parseGeometry(str, polygonCRS, rasterCRS) })
+    val polygon = config.getStringList("input.polygon").asScala.map({
+      str => parseGeometry(str, polygonCRS, rasterCRS).buffer(0).asMultiPolygon.get
+    })
     val lines = config.getStringList("input.vector").asScala.map({ str => toMultiLine(str, linesCRS, rasterCRS) })
 
     (rasterLayerIds, lines, polygon)


### PR DESCRIPTION
## Overview

By passing them through `.buffer(0)` we reduce the chance of intersection / union errors because of lines that are too close to each other.

Connects #42 
Connects https://github.com/WikiWatershed/model-my-watershed/issues/1884

### Demo

```http
http --print HhBb :8090/jobs sync==true timeout==90 context==geoprocessing appName==geoprocessing-1.2.0 classPath==org.wikiwatershed.mmw.geoprocessing.MapshedJob < Failing_TR55.json

POST /jobs?sync=true&timeout=90&context=geoprocessing&appName=geoprocessing-1.2.0&classPath=org.wikiwatershed.mmw.geoprocessing.MapshedJob HTTP/1.1
Accept: application/json, */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 18308
Content-Type: application/json
Host: localhost:8090
User-Agent: HTTPie/0.9.9

{
    "input": {
        "operationType": "RasterGroupedCount",
        "polygon": [
            "{\"type\": \"MultiPolygon\", \"coordinates\": [[[[-75.25428771972655, 40.0013199623656], [-75.22331784007272, 39.96639817059936], [-75.22593140254246, 39.96256060079701], [-75.2257996717998, 39.9624593910953], [-75.2263260561741, 39.9628638160946], [-75.2268219051316, 39.9633223504689], [-75.2273485061725, 39.9637853244265], [-75.2277757520051, 39.9641854244259], [-75.2282714395044, 39.9645898942169], [-75.2287902717952, 39.9649132244248], [-75.2293626499193, 39.9651598629661], [-75.2299955895017, 39.9652442108826], [-75.2309876270002, 39.9653683692158], [-75.2316666676241, 39.9654481015073], [-75.2325136082478, 39.9656220994237], [-75.2331619728301, 39.9657199046318], [-75.2339860499122, 39.96583537234], [-75.2346420124111, 39.9659061337982], [-75.2353822551183, 39.9660127421314], [-75.236045874909, 39.9660744608813], [-75.2367249426163, 39.966266789006], [-75.2371367769906, 39.9666353504638], [-75.2376328207399, 39.9671208650464], [-75.2380904592808, 39.9677190817121], [-75.2383879686553, 39.9681419337948], [-75.2386703176132, 39.9686278827523], [-75.2390212019877, 39.9692443348347], [-75.2392805613623, 39.9697438442089], [-75.2395324259452, 39.9701938254582], [-75.2398453634447, 39.9706301462909], [-75.2400972134444, 39.9710711077486], [-75.2403639967773, 39.971597628581], [-75.240562487402, 39.9720567181637], [-75.2406236676102, 39.9725971817045], [-75.240707520735, 39.973133093162], [-75.2407016134434, 39.973355588995], [-75.2406923249018, 39.9737052483695], [-75.2406080790686, 39.974205469202], [-75.2403946592772, 39.9747104702429], [-75.2403718769856, 39.9752060494088], [-75.2404251249022, 39.9758816775328], [-75.2404862644854, 39.9764131379486], [-75.2405549009437, 39.9769896077394], [-75.2406465405268, 39.9775525410718], [-75.24078373011, 39.9780613108627], [-75.2409056238598, 39.9786917431534], [-75.2410048040679, 39.9793177212774], [-75.2411194353178, 39.9798132160683], [-75.2411423103177, 39.9799120837765], [-75.2414740978172, 39.980004703568], [-75.2415409217754, 39.980023359818], [-75.2417830582334, 39.9800909535679], [-75.242032261358, 39.9800634087762], [-75.2425308467739, 39.9800082952347], [-75.2431792655229, 39.9798717869015], [-75.2438200342719, 39.9798479264849], [-75.2445070071875, 39.9798509754432], [-75.2452394155197, 39.9797683400267], [-75.2458724082271, 39.9797174441935], [-75.246528720726, 39.9796439723186], [-75.2466430248925, 39.9801888223177], [-75.2466842811424, 39.9805204348172], [-75.2467040957258, 39.9806797358586], [-75.246994128017, 39.9811341056496], [-75.2474671228079, 39.9815745785656], [-75.2477004155159, 39.9817401712737], [-75.2477754707241, 39.9817934462736], [-75.2479859832238, 39.9819428712734], [-75.248299653015, 39.982144055648], [-75.248497005098, 39.9822706358561], [-75.2490006217639, 39.9825713837724], [-75.2495498821797, 39.9828450098136], [-75.2499745582207, 39.9833415431461], [-75.2500152311373, 39.9833890921044], [-75.250656232178, 39.9837210723122], [-75.2508963175943, 39.9837606775205], [-75.251464862385, 39.9838544691871], [-75.2521209082174, 39.9838935858537], [-75.2520968353007, 39.98409972752], [-75.2520598696758, 39.9844162868945], [-75.251884529051, 39.9849077035604], [-75.2518690353011, 39.9855744629344], [-75.2519491967593, 39.9860181233503], [-75.2520293196758, 39.986461581683], [-75.2524260967585, 39.9871589785569], [-75.252769346758, 39.9877303525143], [-75.2531434800908, 39.9884368066799], [-75.2533418644655, 39.9894274525117], [-75.25363939259, 39.9902016441772], [-75.2539286217562, 39.9905241098017], [-75.2542039717558, 39.9908311014678], [-75.2548675352964, 39.9912214879256], [-75.2548753061297, 39.9912260587589], [-75.2548841269631, 39.9912377910506], [-75.2552641405042, 39.9917432577165], [-75.2556686290452, 39.9923325087572], [-75.2558593446699, 39.9931159389643], [-75.256210405086, 39.9940972327128], [-75.2561340280028, 39.994818184795], [-75.2558061311283, 39.9954360795857], [-75.2558134832116, 39.9960307108348], [-75.2558167967533, 39.9960397858348], [-75.2560731227945, 39.996741909792], [-75.25613160669636, 39.99694891568091], [-75.25428771972655, 40.0013199623656]]], [[[-75.23537707715741, 39.89994066923886], [-75.24742126464844, 39.891562824552544], [-75.25278495912717, 39.89742355043735], [-75.2526780050915, 39.8975822380709], [-75.2526570665498, 39.8976670276542], [-75.2526053655083, 39.8978763818205], [-75.252517713425, 39.8982312953616], [-75.252327123842, 39.8986912182776], [-75.2520216832175, 39.8993360943182], [-75.2516173332181, 39.9001253484836], [-75.2511674592605, 39.9006623995245], [-75.2510146290524, 39.9012574026486], [-75.2508698925943, 39.9020686109807], [-75.2502975071785, 39.90249781098], [-75.2496567925962, 39.9027379568129], [-75.2487793415559, 39.9033299922287], [-75.2483826446815, 39.9037227755614], [-75.2479095790572, 39.9041292349358], [-75.2475128248911, 39.9045084995186], [-75.2473069707248, 39.9051126130593], [-75.2472992280165, 39.9056036713918], [-75.2473490738498, 39.9058723390997], [-75.2474136925997, 39.9062205995158], [-75.247436382183, 39.9067386224318], [-75.2473753498914, 39.9072523172226], [-75.2473602050998, 39.9078199765967], [-75.2473907675997, 39.9085902609705], [-75.2473068967665, 39.9093607890943], [-75.2472763436415, 39.9099149651352], [-75.2471849373917, 39.910424228676], [-75.2472427332131, 39.91010222329109], [-75.23537707715741, 39.89994066923886]]]]}",
            "{\"type\": \"MultiPolygon\", \"coordinates\": [[[[-75.17517302064924, 39.895823039066926], [-75.17809280734821, 39.89987317326378], [-75.17289333977213, 39.90291967937837], [-75.1728590375071, 39.9026751328547], [-75.1726762427157, 39.902089759939], [-75.172691257299, 39.9015176057732], [-75.1728591520904, 39.900972252649], [-75.1730346197984, 39.9003908484833], [-75.1734163260479, 39.8999758214006], [-75.1740343052136, 39.8996145057761], [-75.1745691916711, 39.8992372266101], [-75.1745911645877, 39.8992217276518], [-75.1748034114623, 39.8988596328606], [-75.1750563291703, 39.8984281495279], [-75.1751174833369, 39.8978964703621], [-75.1752091666701, 39.8970088599468], [-75.1752014885451, 39.8964322266144], [-75.1752090000034, 39.8959366682818], [-75.17517302064924, 39.895823039066926]]], [[[-75.1864197384714, 39.956220841006164], [-75.16759225715431, 39.97056691001811], [-75.1675568760569, 39.9702481181665], [-75.1674881895987, 39.9695409442093], [-75.1673582718906, 39.9689374660852], [-75.1671752448075, 39.9683115535861], [-75.1669770677245, 39.9677757525453], [-75.1666718437667, 39.9671545119213], [-75.1663970698087, 39.9667134317136], [-75.1660080479343, 39.9662409671311], [-75.1657485864764, 39.9657773379651], [-75.1654816437685, 39.9652416254659], [-75.1651839739773, 39.9647104754667], [-75.1648484218945, 39.9640937785927], [-75.1645124864783, 39.9636212306768], [-75.1639708541875, 39.9631219504692], [-75.1632079271054, 39.9621905233873], [-75.1630927177305, 39.9620309733876], [-75.162811458356, 39.9616414640132], [-75.16241461044, 39.9610834098474], [-75.1619339604406, 39.9605164598482], [-75.1615524979413, 39.9599628879741], [-75.1613310573166, 39.9594631473499], [-75.1609342802339, 39.9587699494343], [-75.1606673021093, 39.9580360150604], [-75.1605149937762, 39.9575181494362], [-75.1602936791932, 39.9569102921456], [-75.1600954010685, 39.9562888848548], [-75.1599044187772, 39.9556629713142], [-75.159759422944, 39.9551405911066], [-75.1598433416939, 39.9545728525658], [-75.1603315916931, 39.9541892692331], [-75.1608583406507, 39.9538416504836], [-75.1615981218995, 39.9533856306927], [-75.1623230802317, 39.9530107004849], [-75.162979213564, 39.9526223556938], [-75.1635438906465, 39.9523873046526], [-75.1641541343956, 39.9520891161113], [-75.164748983353, 39.9517819359035], [-75.1653139010604, 39.9515018254872], [-75.1661070510592, 39.9513565411125], [-75.1668703031414, 39.9511031619462], [-75.1676255614735, 39.9508723202799], [-75.1684340510556, 39.9505738223637], [-75.1690446677213, 39.9504377859056], [-75.1697236916786, 39.9503061494474], [-75.1703184395943, 39.9501205754894], [-75.1708754312601, 39.949903527573], [-75.1714249062593, 39.9496098890319], [-75.1720199270917, 39.9492441056991], [-75.172477742716, 39.9488740213247], [-75.1729888937568, 39.9483281713255], [-75.1732405270898, 39.9478727879929], [-75.1736222750059, 39.9472235046605], [-75.1738204677139, 39.9467637057029], [-75.1740571052135, 39.9463128557036], [-75.1743470781298, 39.9456907307046], [-75.1747741041708, 39.9447350557061], [-75.1751176562535, 39.9439011140407], [-75.17507167493407, 39.94401272954249], [-75.1864197384714, 39.956220841006164]]]]}",
            "{\"type\": \"Polygon\", \"coordinates\": [[[-75.22331784007272, 39.96639817059936], [-75.20622253417969, 39.94712141785606], [-75.20690917968749, 39.919742720952726], [-75.23537707715741, 39.89994066923886], [-75.2472427332131, 39.91010222329109], [-75.2471849373917, 39.910424228676], [-75.2467574051007, 39.9107945453421], [-75.2459869384352, 39.9113818182578], [-75.2453080436446, 39.911707622424], [-75.2443236207295, 39.9122818224232], [-75.2440813905215, 39.9124312120063], [-75.2437592259387, 39.9126299005476], [-75.2432249853145, 39.913027459922], [-75.2425841759405, 39.9134837942963], [-75.2419129196915, 39.9140167828371], [-75.2415389509421, 39.9144590495031], [-75.2411880134426, 39.9148967599191], [-75.2408677082348, 39.9154200015849], [-75.2405700269853, 39.9159296807508], [-75.2402802446941, 39.9163987974167], [-75.2400207519862, 39.9168498213744], [-75.2398300134448, 39.917309729707], [-75.239677594695, 39.917954254706], [-75.2394942624036, 39.9185447817884], [-75.2394179624037, 39.9192116744957], [-75.2393724446954, 39.9200001359528], [-75.2389983999044, 39.9204333828271], [-75.2387235999048, 39.9209069703264], [-75.2383805769887, 39.9214302578256], [-75.2381132509474, 39.9219533744915], [-75.2379152082394, 39.9224222953241], [-75.2376862894898, 39.9230534578231], [-75.2374040353236, 39.9237027505304], [-75.2371826936572, 39.9242077599046], [-75.2367936540745, 39.9250735046949], [-75.2365569301165, 39.9255695328192], [-75.2362977915752, 39.9260385765684], [-75.2355421384514, 39.9264320526095], [-75.2349171801191, 39.9266223755259], [-75.2349167019941, 39.9266225213592], [-75.2343598624116, 39.9268759244838], [-75.2337798290791, 39.927192444275], [-75.23323058533, 39.9276395380243], [-75.2326585290809, 39.9281542526068], [-75.2324714936645, 39.9283255546899], [-75.2321852947067, 39.9285876765645], [-75.2321190780401, 39.9286253953144], [-75.2315979874159, 39.928922217189], [-75.2309799436669, 39.9291441921886], [-75.2303773384594, 39.9292850453134], [-75.2295914978357, 39.9294217526049], [-75.2289732967949, 39.9296031817713], [-75.2289354353367, 39.9300897901038], [-75.2289729113783, 39.930238245312], [-75.2290877488781, 39.9306931453112], [-75.229156542628, 39.9312516223937], [-75.2294386249192, 39.9317195859346], [-75.2299040707518, 39.932119598434], [-75.2302626999179, 39.9326189442666], [-75.229804855127, 39.9329622203077], [-75.2290419467948, 39.9334097182237], [-75.2281492832545, 39.9339971223894], [-75.2275846749221, 39.9343586265555], [-75.2270814290895, 39.9346974848883], [-75.2264481561739, 39.9352032932209], [-75.2259218072164, 39.9356412828035], [-75.2256379186751, 39.9362279786359], [-75.2255705218003, 39.9363672640524], [-75.2256392707584, 39.9369212390516], [-75.2257612509666, 39.937533681759], [-75.2258835113831, 39.9380064536332], [-75.2260132592995, 39.9385332796741], [-75.2258604467998, 39.9391147234231], [-75.225311111384, 39.9393545463394], [-75.2247466613848, 39.9395583713391], [-75.2240064978443, 39.939834598422], [-75.2238601822195, 39.9398688713387], [-75.2233277728454, 39.9399935807135], [-75.2230684124291, 39.9404355640461], [-75.2229080124293, 39.9409404265453], [-75.2227783290962, 39.9414452275862], [-75.2226179822215, 39.9419681098771], [-75.2224806415967, 39.9424819442513], [-75.2223588822219, 39.943063307792], [-75.2221603113888, 39.943532202583], [-75.2219313790976, 39.9441137775821], [-75.2219848832641, 39.9446002150813], [-75.2219010530559, 39.9451454650804], [-75.2218835645143, 39.9453655442468], [-75.2218627384726, 39.9456275682047], [-75.2217484343062, 39.9461413494539], [-75.221677766598, 39.9463622942452], [-75.221595607223, 39.9466191640365], [-75.2213288186818, 39.9472638817438], [-75.2212142363903, 39.947809197368], [-75.2212600895152, 39.9483001546589], [-75.2215423801398, 39.9488311890331], [-75.222244444722, 39.9489559848662], [-75.222930910346, 39.9492384775741], [-75.2229592780543, 39.9492506942407], [-75.2235870280533, 39.9495210254904], [-75.224235566594, 39.9497224952817], [-75.2249832749262, 39.9500409046562], [-75.2255860884669, 39.9503550713223], [-75.2262039092993, 39.9507773317384], [-75.2266541478402, 39.9512990317376], [-75.2265778717987, 39.9517992192368], [-75.2262877842991, 39.9522502796528], [-75.2259521967997, 39.9526608827771], [-75.2258708926331, 39.9527656338186], [-75.2256090155502, 39.9531030359014], [-75.2252501395091, 39.9535542275674], [-75.2248993645096, 39.9540234286084], [-75.2246476134683, 39.9545690140242], [-75.2243348207605, 39.9552453494398], [-75.2241136353442, 39.9557413192307], [-75.2236786968032, 39.9564359192296], [-75.2235183061784, 39.9569543036038], [-75.2234420176368, 39.9574589931863], [-75.2232744093038, 39.9581215421437], [-75.2230682738875, 39.9588652515175], [-75.2229462155543, 39.9593610296417], [-75.2231672790956, 39.959833620266], [-75.2235795895116, 39.9603824265151], [-75.2239914405527, 39.9607915900561], [-75.2243499103438, 39.9612053483889], [-75.2247621436765, 39.9616144890132], [-75.2252653384674, 39.9619784108876], [-75.2257996717998, 39.9624593910953], [-75.22593140254246, 39.96256060079701], [-75.22331784007272, 39.96639817059936]]]}",
            "{\"type\": \"Polygon\", \"coordinates\": [[[-75.22331784007272, 39.96639817059936], [-75.21171569824219, 39.98343393295322], [-75.17507167493407, 39.94401272954249], [-75.1751176562535, 39.9439011140407], [-75.1753157822949, 39.9434187952914], [-75.1754074937531, 39.9429456296672], [-75.1756364510444, 39.9420758296686], [-75.1757811583358, 39.941589083836], [-75.1758651489607, 39.9411069286284], [-75.1758726812524, 39.9406203827958], [-75.1757278687526, 39.9400619807133], [-75.1753618062531, 39.9395174369642], [-75.1749647406288, 39.9390134827983], [-75.1744613645879, 39.9384060744659], [-75.173935113547, 39.9380104296749], [-75.1735229864644, 39.9376146192588], [-75.1730424104234, 39.9371963703011], [-75.1725312687576, 39.9368322400933], [-75.1718674062586, 39.9362430682193], [-75.1711960489679, 39.9357259921784], [-75.1706544489688, 39.9353168494707], [-75.1701050250113, 39.9349977973879], [-75.1696320083454, 39.9346606192634], [-75.1688995020965, 39.9341030734309], [-75.168411178139, 39.9337884369731], [-75.1680552916812, 39.9335167765568], [-75.167945830223, 39.9334332213487], [-75.1679491906397, 39.9333335588488], [-75.1679792812646, 39.9324404317668], [-75.1679915208479, 39.9320771651007], [-75.1682434468892, 39.9310046307274], [-75.168388468764, 39.9304818359366], [-75.1684033864723, 39.9304471463533], [-75.168617195847, 39.9299499203124], [-75.1687315937634, 39.929323565105], [-75.1688078468883, 39.9288008807308], [-75.1689604718881, 39.9281068942736], [-75.1691969635544, 39.9274623411496], [-75.1693193448042, 39.926962120317], [-75.1693802864708, 39.9264664869845], [-75.1695403229289, 39.9259616901102], [-75.1699602020949, 39.9255376088609], [-75.1704254854275, 39.9251404911532], [-75.1708220302185, 39.9247524890704], [-75.1712418479262, 39.9243103838628], [-75.1715699208424, 39.9238909296968], [-75.1717529802171, 39.9233906078226], [-75.1719588854251, 39.9228136682401], [-75.1721573114665, 39.9218808484499], [-75.1724166010494, 39.9205785276186], [-75.1724853979243, 39.9200153067861], [-75.1726532031324, 39.9194158963704], [-75.1727294177156, 39.9188977119962], [-75.1727752812572, 39.9183750692887], [-75.1727523166739, 39.9178254994978], [-75.1725081635493, 39.9172807609571], [-75.1722564583413, 39.9166459369997], [-75.1719664687585, 39.916195869292], [-75.1719130520918, 39.9155967890846], [-75.1719893229251, 39.9151011297104], [-75.1719740239668, 39.9145380317946], [-75.1722260395914, 39.9134069120047], [-75.1724090072994, 39.9124470817979], [-75.1725388260492, 39.9118657578404], [-75.1727217895906, 39.9112032536748], [-75.172882003132, 39.9105002338842], [-75.1731645593816, 39.9093150120111], [-75.173309191673, 39.9086750838871], [-75.1734389562561, 39.9077919140968], [-75.1735612229226, 39.9069808370147], [-75.1737366479223, 39.9060931036827], [-75.1737746812556, 39.905516402642], [-75.1738434750055, 39.9049621963928], [-75.1738815979221, 39.9044215338936], [-75.1733476500063, 39.9040574297276], [-75.1728441062571, 39.9037158036865], [-75.1729279010486, 39.9031660724373], [-75.17289333977213, 39.90291967937837], [-75.20062386976126, 39.88667162552734], [-75.2008665832969, 39.886831043296], [-75.2014542978793, 39.887208444337], [-75.2020722416283, 39.8875407464199], [-75.2026748957941, 39.8878955797526], [-75.2028443832938, 39.8879791849608], [-75.2036668489176, 39.8883848932936], [-75.2041549978752, 39.8886993766264], [-75.204712005166, 39.8889371578761], [-75.2053377197483, 39.8886837807931], [-75.2060470207888, 39.8880247860025], [-75.206596439538, 39.8874381537117], [-75.2069244030791, 39.8869915849624], [-75.2071990124538, 39.8864234662133], [-75.2073131968286, 39.8862441120469], [-75.2077101072446, 39.8856206641312], [-75.2084275093268, 39.8845156557996], [-75.2088317759928, 39.8839292808005], [-75.2092209249506, 39.8834195151763], [-75.2099228291162, 39.8824046255945], [-75.2102660270323, 39.8819309880952], [-75.2107545634899, 39.8813039078879], [-75.2110441926561, 39.8808844089302], [-75.21134975569893, 39.88038704415137], [-75.2120590209961, 39.879971466780596], [-75.23537707715741, 39.89994066923886], [-75.20690917968749, 39.919742720952726], [-75.20622253417969, 39.94712141785606], [-75.22331784007272, 39.96639817059936]]]}"
        ],
        "polygonCRS": "LatLng",
        "rasterCRS": "ConusAlbers",
        "rasters": [
            "nlcd-2011-30m-epsg5070-0.10.0",
            "ssurgo-hydro-groups-30m-epsg5070-0.10.0"
        ],
        "zoom": 0
    }
}

HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Length: 721
Content-Type: application/json; charset=UTF-8
Date: Tue, 11 Jul 2017 03:37:12 GMT
Server: spray-can/1.3.3

{
    "result": {
        "List(11, -2147483648)": 2102,
        "List(21, -2147483648)": 3933,
        "List(21, 1)": 1,
        "List(21, 2)": 10,
        "List(21, 4)": 12,
        "List(21, 7)": 284,
        "List(22, -2147483648)": 4984,
        "List(22, 7)": 122,
        "List(23, -2147483648)": 17703,
        "List(23, 7)": 152,
        "List(24, -2147483648)": 24253,
        "List(24, 7)": 11,
        "List(41, -2147483648)": 432,
        "List(41, 2)": 10,
        "List(41, 7)": 21,
        "List(43, -2147483648)": 30,
        "List(52, -2147483648)": 29,
        "List(71, -2147483648)": 89,
        "List(81, -2147483648)": 108,
        "List(82, -2147483648)": 44,
        "List(90, -2147483648)": 601,
        "List(90, 7)": 117,
        "List(95, -2147483648)": 428,
        "List(95, 7)": 29
    }
}
```

## Testing Instructions

Download this archive of sample requests: [overlapping-test.zip](https://github.com/WikiWatershed/mmw-geoprocessing/files/1137674/overlapping-test.zip)

For each `request` file, generate a corresponding `response` file with the current geoprocessing service. In `fish` shell, you could do:

```
for f in *; set k (echo $f | string replace request response); http :8090/jobs sync==true timeout==90 context==geoprocessing appName==geoprocessing-1.2.0 classPath==org.wikiwatershed.mmw.geoprocessing.MapshedJob < $f > $k; end
```

Then, check out this branch and build and deploy the geoprocessing JAR to the worker VM and reload the Spark JobServer service:

```
cd ~/dev/mmwg/; and ./sbt "project summary" assembly; and mv -f summary/target/scala-2.10/mmw-geoprocessing-assembly-1.2.0.jar ~/dev/mmw/src/mmw/; and cd ~/dev/mmw/; and vagrant ssh worker -c "sudo mv /opt/app/mmw-geoprocessing-assembly-1.2.0.jar /opt/geoprocessing/mmw-geoprocessing-1.2.0.jar && sudo service spark-jobserver restart"
```

Then generate responses for the above requests again and diff them with the previous set. Ensure that they are identical, except for `overlap-test-request.json` which should only have a response on this branch.