### PR TITLE
Add Travis badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mmw-geoprocessing
 
+[![Build Status](https://travis-ci.org/WikiWatershed/mmw-geoprocessing.svg?branch=develop)](https://travis-ci.org/WikiWatershed/mmw-geoprocessing)
+
 A [Spark Job Server](https://github.com/spark-jobserver/spark-jobserver) job for Model My Watershed geoprocessing.
 
 ## Usage


### PR DESCRIPTION
## Overview

This PR adds the Travis badge (and a link to the Travis build job) to the README.

Connects #58 

## Testing Instructions
- look at the README for this branch, verify that you see the badge, click the image, and verify that it takes you to the Travis build job
