### PR TITLE
Add missing step to deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Deployments to GitHub Releases are handled through [Travis-CI](https://travis-ci
 $ git flow release start 0.1.0
 $ vim CHANGELOG.md
 $ vim project/build.scala
+$ git add CHANGELOG.md project/build.scala
 $ git commit -m "0.1.0"
 $ git flow release publish 0.1.0
 $ git flow release finish 0.1.0


### PR DESCRIPTION
## Overview

This PR adds a missing step from the deployment instructions: adding `CHANGELOG.md` & `projects/build.scala` to the release git commit.

## Testing Instructions
- trivial but:
    - create a file in a git repo then run git commit without having git add-ed it first
