### PR TITLE
Implement Raster Grouped Average operation

### DIFF
--- a/api/src/main/scala/Geoprocessing.scala
+++ b/api/src/main/scala/Geoprocessing.scala
@@ -1,13 +1,12 @@
 package org.wikiwatershed.mmw.geoprocessing
 
-import java.util.concurrent.atomic.LongAdder
+import java.util.concurrent.atomic.{LongAdder, DoubleAdder}
 
 import collection.concurrent.TrieMap
 
 import geotrellis.raster._
 import geotrellis.raster.rasterize._
 import geotrellis.vector._
-import geotrellis.vector.io._
 
 import geotrellis.spark._
 
@@ -18,10 +17,124 @@ trait Geoprocessing extends Utils {
     * @param   input  The InputData
     * @return         A histogram of results
     */
-  def getRasterGroupedCount(input: InputData): Result = {
+  def getRasterGroupedCount(input: InputData): ResultInt = {
     val aoi = createAOIFromInput(input)
     val rasterLayers = cropRastersToAOI(input.rasters, input.zoom, aoi)
-    Result(rasterGroupedCount(rasterLayers, aoi))
+    ResultInt(rasterGroupedCount(rasterLayers, aoi))
+  }
+
+  /**
+    * For an InputData object, return a histogram of raster grouped average
+    * results.
+    *
+    * @param   input  The InputData
+    * @return         A histogram of results
+    */
+  def getRasterGroupedAverage(input: InputData): ResultDouble = {
+    val aoi = createAOIFromInput(input)
+    val rasterLayers = cropRastersToAOI(input.rasters, input.zoom, aoi)
+    val targetLayer = input.targetRaster match {
+      case Some(targetRaster) =>
+        cropSingleRasterToAOI(targetRaster, input.zoom, aoi)
+      case None =>
+        throw new Exception("Request data missing required 'targetRaster'.")
+    }
+
+    val average =
+      if (rasterLayers.isEmpty) rasterAverage(targetLayer, aoi)
+      else rasterGroupedAverage(rasterLayers, targetLayer, aoi)
+
+    ResultDouble(average)
+  }
+
+  /**
+    * Return the average pixel value from a target raster and a MultiPolygon
+    * area of interest.
+    *
+    * @param   targetLayer   The target TileLayerCollection
+    * @param   multiPolygon  The AOI as a MultiPolygon
+    * @return                A one element map averaging the pixel values
+    */
+  private def rasterAverage(
+    targetLayer: TileLayerCollection[SpatialKey],
+    multiPolygon: MultiPolygon
+  ): Map[String, Double] = {
+    val update = (newValue: Double, pixelValue: (DoubleAdder, LongAdder)) => {
+      pixelValue match {
+        case (accumulator, counter) => accumulator.add(newValue); counter.increment()
+      }
+    }
+
+    val metadata = targetLayer.metadata
+    val pixelValue = ( new DoubleAdder, new LongAdder )
+
+    targetLayer.par.foreach({ case (key, tile) =>
+      val re = RasterExtent(metadata.mapTransform(key), metadata.layout.tileCols,
+        metadata.layout.tileRows)
+
+      Rasterizer.foreachCellByMultiPolygon(multiPolygon, re) { case (col, row) =>
+        val targetLayerData = tile.getDouble(col, row)
+
+        val targetLayerValue =
+          if (isData(targetLayerData)) targetLayerData
+          else 0.0
+
+        update(targetLayerValue, pixelValue)
+      }
+    })
+
+    pixelValue match {
+      case (accumulator, counter) => Map("List(0)" -> accumulator.sum / counter.sum)
+    }
+  }
+
+  /**
+    * Return the average pixel value from a target raster and a MultiPolygon
+    * area of interest.
+    *
+    * @param   rasterLayers  A sequence of TileLayerCollections
+    * @param   targetLayer   The target TileLayerCollection
+    * @param   multiPolygon  The AOI as a MultiPolygon
+    * @return                A map of targetRaster pixel value averages
+    */
+  private def rasterGroupedAverage(
+    rasterLayers: Seq[TileLayerCollection[SpatialKey]],
+    targetLayer: TileLayerCollection[SpatialKey],
+    multiPolygon: MultiPolygon
+  ): Map[String, Double] = {
+    val init = () => ( new DoubleAdder, new LongAdder )
+    val update = (newValue: Double, pixelValue: (DoubleAdder, LongAdder)) => {
+      pixelValue match {
+        case (accumulator, counter) => accumulator.add(newValue); counter.increment()
+      }
+    }
+
+    val metadata = targetLayer.metadata
+    val pixelGroups: TrieMap[List[Int], (DoubleAdder, LongAdder)] = TrieMap.empty
+
+    joinCollectionLayers(targetLayer +: rasterLayers).par
+      .foreach({ case (key, targetTile :: tiles) =>
+        val extent: Extent = metadata.mapTransform(key)
+        val re: RasterExtent = RasterExtent(extent, metadata.layout.tileCols,
+            metadata.layout.tileRows)
+
+        Rasterizer.foreachCellByMultiPolygon(multiPolygon, re) { case (col, row) =>
+          val pixelKey: List[Int] = tiles.map(_.get(col, row)).toList
+          val pixelValues = pixelGroups.getOrElseUpdate(pixelKey, init())
+          val targetLayerData = targetTile.getDouble(col, row)
+
+          val targetLayerValue =
+            if (isData(targetLayerData)) targetLayerData
+            else 0.0
+
+          update(targetLayerValue, pixelValues)
+        }
+      })
+
+    pixelGroups
+      .mapValues { case (accumulator, counter) => accumulator.sum / counter.sum }
+      .map { case (k, v) => k.toString -> v }
+      .toMap
   }
 
   /**

--- a/api/src/main/scala/Utils.scala
+++ b/api/src/main/scala/Utils.scala
@@ -33,9 +33,23 @@ trait Utils {
     zoom: Int,
     aoi: MultiPolygon
   ): Seq[TileLayerCollection[SpatialKey]] =
-    rasterIds
-      .map { str => LayerId(str, zoom) }
-      .map { layer => fetchCroppedLayer(layer, aoi)}
+    rasterIds.map { str => cropSingleRasterToAOI(str, zoom, aoi) }
+
+  /**
+    * Given a zoom level & area of interest, transform a raster filename into a
+    * TileLayerCollection[SpatialKey].
+    *
+    * @param   rasterId   The raster filename
+    * @param   zoom       The input zoom level
+    * @param   aoi        A MultiPolygon area of interest
+    * @return             TileLayerCollection[SpatialKey]
+    */
+  def cropSingleRasterToAOI(
+    rasterId: String,
+    zoom: Int,
+    aoi: MultiPolygon
+  ): TileLayerCollection[SpatialKey] =
+    fetchCroppedLayer(LayerId(rasterId, zoom), aoi)
 
   /**
     * Given input data containing a polygonCRS & a raster CRS, transform an


### PR DESCRIPTION
## Overview

This PR implements the "RasterGroupedAverage" operation. Behind the API interface there are two ops: `rasterAverage` for requests which don't include a list of rasters, and `rasterGroupedAverage` for those which do. Some implementation details are in the "Notes" section below.


Connects #52

## Demo

https://github.com/WikiWatershed/mmw-geoprocessing/issues/52 has two sample inputs: one for the `rasterGroupedAverage` and another for `rasterAverage`.

<details>
<summary>
Current output for the `rasterGroupedAverage` input:
</summary>

```
{
	"result": {
		"List(42)": 0.23512719654500847,
		"List(22)": 0.21115289390947675,
		"List(43)": 0.2440073603213253,
		"List(71)": 0.26802137526366693,
		"List(41)": 0.268620081816594,
		"List(21)": 0.23515533595797652,
		"List(24)": 0.1859889512692598,
		"List(31)": 0.27985624785802954,
		"List(90)": 0.25720720833308114,
		"List(52)": 0.27157785493664266,
		"List(11)": 0.2281515911560167,
		"List(23)": 0.20484685031909086,
		"List(82)": 0.27604142433856804,
		"List(81)": 0.2714132968948771,
		"List(95)": 0.31307519406197576
	}
}
```

</details>

<details>
<summary>
Current output for `rasterAverage` op
</summary>

```
{
	"result": {
		"List(0)": 9.937211446569115
	}
}
```

</details>

## Notes

As noted in comments on #52 I encountered some initial difficulties in ensuring the `rasterGroupedAverage` would return the same results each time: the values were very close to the desired output, but off by a tenth or so of a decimal each time and not deterministic.

It turns out this was because I was trying to store the values as a list of doubles, then `list.sum / list.length` to get the final value. Since these ops use `.par` to parallelize and I was trying out resetting the values by taking the old list and concating the new target value, I think parallelizing it meant some of these intervening updates would be overwritten later.

To fix it while keeping the `.par` call I ended up using a tuple of a `DoubleAdder` & `LongAdder` to store the accumulator target values and the count of values, respectively, since the `...Adder`s are designed to be threadsafe: 

https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/DoubleAdder.html 

## Testing
- get this branch, then `./scripts/server`
- try the sample inputs from #52 and verify that they return identical output
- try additional inputs with known output values & verify that they're identical too
- verify that that posting input for the `rasterGroupedCount` operation still works as expected
