### PR TITLE
Implement RasterLinesJoin operation

### DIFF
--- a/api/src/main/resources/application.conf
+++ b/api/src/main/resources/application.conf
@@ -3,3 +3,9 @@ geoprocessing {
     hostname = "0.0.0.0"
     s3bucket = "datahub-catalogs-us-east-1"
 }
+
+akka.http {
+  parsing {
+    max-content-length = 50m
+  }
+}

--- a/api/src/main/scala/Utils.scala
+++ b/api/src/main/scala/Utils.scala
@@ -58,13 +58,15 @@ trait Utils {
     * @param   input  InputData including polygons, polygonCRS, and rasterCRS
     * @return         A MultiPolygon
     */
-  def createAOIFromInput(input: InputData): MultiPolygon =
-    input.polygon.map { str =>
-      parseGeometry(str, getCRS(input.polygonCRS), getCRS(input.rasterCRS))
-        .buffer(0)
-        .asMultiPolygon
-        .get
-    }.unionGeometries.asMultiPolygon.get
+  def createAOIFromInput(input: InputData): MultiPolygon = {
+    val parseGeom =
+      parseGeometry(_: String, getCRS(input.polygonCRS), getCRS(input.rasterCRS))
+
+    input.polygon.map { str => parseGeom(str).buffer(0).asMultiPolygon.get }
+      .unionGeometries
+      .asMultiPolygon
+      .get
+  }
 
   /**
     * Transform the incoming GeoJSON into a [[MultiPolygon]] in the

--- a/api/src/main/scala/Utils.scala
+++ b/api/src/main/scala/Utils.scala
@@ -86,6 +86,43 @@ trait Utils {
   }
 
   /**
+    * Given an input vector along with a vectorCRS and rasterCRS, return a Seq
+    * of MultiLines
+    *
+    * @param   vector     A list of strings representing the input vector
+    * @param   vectorCRS  CRS for the input vector
+    * @param   rasterCRS  CRS for the input raster IDs
+    * @return             A list of MultiLines
+    */
+  def createMultiLineFromInput(
+    vector: List[String],
+    vectorCRS: String,
+    rasterCRS: String
+  ): Seq[MultiLine] = {
+    val parseVector =
+      parseMultiLineString(_: String, getCRS(vectorCRS), getCRS(rasterCRS))
+
+    vector.map { str => parseVector(str) }
+  }
+
+  /**
+    * Transform the incoming stream vector into a MultiLine in the
+    * destination CRS.
+    *
+    * @param   geoJson  The incoming geometry
+    * @param   srcCRS   The CRS that the incoming geometry is in
+    * @param   destCRS  The CRS that the outgoing geometry should be in
+    * @return           A MultiLine
+    */
+  def parseMultiLineString(geoJson: String, srcCRS: CRS, destCRS: CRS): MultiLine = {
+    geoJson.parseJson.convertTo[Geometry] match {
+      case l: Line => MultiLine(l.reproject(srcCRS, destCRS))
+      case ml: MultiLine => ml.reproject(srcCRS, destCRS)
+      case _ => MultiLine()
+    }
+  }
+
+  /**
     * For a given config and CRS key, return one of several recognized
     * [[geotrellis.proj4.CRS]]s, or raise an error.
     *

--- a/api/src/main/scala/WebServer.scala
+++ b/api/src/main/scala/WebServer.scala
@@ -15,7 +15,9 @@ case class InputData(
   zoom: Int,
   polygonCRS: String,
   rasterCRS: String,
-  polygon: List[String]
+  polygon: List[String],
+  vectorCRS: Option[String],
+  vector: Option[List[String]]
 )
 
 case class PostRequest(input: InputData)
@@ -23,7 +25,7 @@ case class ResultInt(result: Map[String, Int])
 case class ResultDouble(result: Map[String, Double])
 
 object PostRequestProtocol extends DefaultJsonProtocol {
-  implicit val inputFormat = jsonFormat7(InputData)
+  implicit val inputFormat = jsonFormat9(InputData)
   implicit val postFormat = jsonFormat1(PostRequest)
   implicit val resultFormat = jsonFormat1(ResultInt)
   implicit val resultDoubleFormat = jsonFormat1(ResultDouble)
@@ -46,6 +48,8 @@ object WebServer extends HttpApp with App with LazyLogging with Geoprocessing {
               complete(getRasterGroupedCount(data.input))
             case "RasterGroupedAverage" =>
               complete(getRasterGroupedAverage(data.input))
+            case "RasterLinesJoin" =>
+              complete(getRasterLinesJoin(data.input))
             case _ =>
               throw new Exception(s"Unknown operationType: ${data.input.operationType}")
           }


### PR DESCRIPTION
## Overview

This PR implements the RasterLinesJoin geoprocessing operation used in MapShed.

~All the infrastructure's wired up and operation's returns a count, but the count's currently slightly off.~ This is fixed now: my initial implementation was double counting values because the same row/col cells would be visited multiple times; my second try undercounted cells because it tried to throw out cells which had already been visited, but didn't track the visited cells correctly.

Now, we initialize the TrieMap to have a key which is a tuple comprising 

- a list of the raster values
- the pixel col/row
- the SpatialKey

```scala
var pixelGroups: TrieMap[(List[Int], List[Int], SpatialKey), Int] = TrieMap.empty
```

... and then we only count the cell if it hasn't already been visited in that tile

At the end we drop the cell col/row & SpatialKey...

```scala
.map { case ((key, _, _), value) => (key, value) }
```

...then group by the raster values and sum.

Connects #53

## Testing
- get this branch, then `./scripts/server` to run sbt ~reStart
- post the request json included in this zip file to `:8090/run`
[nlcd-streams-request-response.zip](https://github.com/WikiWatershed/mmw-geoprocessing/files/1260526/nlcd-streams-request-response.zip)`
- verify that the output matches the expected response
- test the RasterGroupedCount, RasterAverage, and RasterGroupedAverage operations and verify that they still return the values expected, too.