### PR TITLE
Collections API: Use Futures

### DIFF
--- a/api/src/main/scala/Geoprocessing.scala
+++ b/api/src/main/scala/Geoprocessing.scala
@@ -1,6 +1,8 @@
 package org.wikiwatershed.mmw.geoprocessing
 
 import java.util.concurrent.atomic.{LongAdder, DoubleAdder}
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import collection.concurrent.TrieMap
 
@@ -17,10 +19,13 @@ trait Geoprocessing extends Utils {
     * @param   input  The InputData
     * @return         A histogram of results
     */
-  def getRasterGroupedCount(input: InputData): ResultInt = {
+  def getRasterGroupedCount(input: InputData): Future[ResultInt] = {
     val aoi = createAOIFromInput(input)
-    val rasterLayers = cropRastersToAOI(input.rasters, input.zoom, aoi)
-    ResultInt(rasterGroupedCount(rasterLayers, aoi))
+    val futureLayers = cropRastersToAOI(input.rasters, input.zoom, aoi)
+
+    futureLayers.map { layers =>
+      ResultInt(rasterGroupedCount(layers, aoi))
+    }
   }
 
   /**
@@ -30,9 +35,9 @@ trait Geoprocessing extends Utils {
     * @param   input  The InputData
     * @return         A histogram of results
     */
-  def getRasterGroupedAverage(input: InputData): ResultDouble = {
+  def getRasterGroupedAverage(input: InputData): Future[ResultDouble] = {
     val aoi = createAOIFromInput(input)
-    val rasterLayers = cropRastersToAOI(input.rasters, input.zoom, aoi)
+    val futureLayers = cropRastersToAOI(input.rasters, input.zoom, aoi)
     val targetLayer = input.targetRaster match {
       case Some(targetRaster) =>
         cropSingleRasterToAOI(targetRaster, input.zoom, aoi)
@@ -40,11 +45,13 @@ trait Geoprocessing extends Utils {
         throw new Exception("Request data missing required 'targetRaster'.")
     }
 
-    val average =
-      if (rasterLayers.isEmpty) rasterAverage(targetLayer, aoi)
-      else rasterGroupedAverage(rasterLayers, targetLayer, aoi)
+    futureLayers.map { rasterLayers =>
+      val average =
+        if (rasterLayers.isEmpty) rasterAverage(targetLayer, aoi)
+        else rasterGroupedAverage(rasterLayers, targetLayer, aoi)
 
-    ResultDouble(average)
+      ResultDouble(average)
+    }
   }
 
   /**
@@ -53,9 +60,9 @@ trait Geoprocessing extends Utils {
     * @param   input  The InputData
     * @return         A histogram of results
     */
-  def getRasterLinesJoin(input: InputData): ResultInt = {
+  def getRasterLinesJoin(input: InputData): Future[ResultInt] = {
     val aoi = createAOIFromInput(input)
-    val rasterLayers = cropRastersToAOI(input.rasters, input.zoom, aoi)
+    val futureLayers = cropRastersToAOI(input.rasters, input.zoom, aoi)
     val lines = input.vector match {
       case Some(vector) =>
         input.vectorCRS match {
@@ -67,7 +74,10 @@ trait Geoprocessing extends Utils {
       case None =>
         throw new Exception("Request data missing required 'vector'.")
     }
-    ResultInt(rasterLinesJoin(rasterLayers, lines))
+
+    futureLayers.map { rasterLayers =>
+      ResultInt(rasterLinesJoin(rasterLayers, lines))
+    }
   }
 
   private case class TilePixel(key: SpatialKey, col: Int, row: Int)

--- a/api/src/main/scala/Geoprocessing.scala
+++ b/api/src/main/scala/Geoprocessing.scala
@@ -95,7 +95,7 @@ trait Geoprocessing extends Utils {
     lines: Seq[MultiLine]
   ): Map[String, Int] = {
     val metadata = rasterLayers.head.metadata
-    var pixelGroups: TrieMap[(List[Int], TilePixel), Int] = TrieMap.empty
+    val pixelGroups: TrieMap[(List[Int], TilePixel), Int] = TrieMap.empty
 
     joinCollectionLayers(rasterLayers).par
       .foreach({ case (key, tiles) =>
@@ -223,7 +223,7 @@ trait Geoprocessing extends Utils {
     // assume all the layouts are the same
     val metadata = rasterLayers.head.metadata
 
-    var pixelGroups: TrieMap[List[Int], LongAdder] = TrieMap.empty
+    val pixelGroups: TrieMap[List[Int], LongAdder] = TrieMap.empty
 
     joinCollectionLayers(rasterLayers).par
       .foreach({ case (key, tiles) =>

--- a/api/src/main/scala/Utils.scala
+++ b/api/src/main/scala/Utils.scala
@@ -4,12 +4,10 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import spray.json._
-import spray.json.DefaultJsonProtocol._
 
 import geotrellis.proj4.{CRS, ConusAlbers, LatLng, WebMercator}
 
 import geotrellis.raster._
-import geotrellis.raster.rasterize._
 import geotrellis.vector._
 import geotrellis.vector.io._
 import geotrellis.spark._

--- a/api/src/main/scala/Utils.scala
+++ b/api/src/main/scala/Utils.scala
@@ -1,5 +1,8 @@
 package org.wikiwatershed.mmw.geoprocessing
 
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
@@ -32,8 +35,10 @@ trait Utils {
     rasterIds: List[String],
     zoom: Int,
     aoi: MultiPolygon
-  ): Seq[TileLayerCollection[SpatialKey]] =
-    rasterIds.map { str => cropSingleRasterToAOI(str, zoom, aoi) }
+  ): Future[Seq[TileLayerCollection[SpatialKey]]] =
+    Future.sequence {
+      rasterIds.map { str => Future(cropSingleRasterToAOI(str, zoom, aoi))}
+    }
 
   /**
     * Given a zoom level & area of interest, transform a raster filename into a


### PR DESCRIPTION
## Overview

By using Futures instead of immediate values we can fetch tiles for multiple layers in parallel, thus speeding up the entire operation as the IO is the most expensive part.

Tagging @lossyrob for code review.

Connects #67 

### Demo

Here are some recorded run times when running a RasterGroupedCount operation for HUC-08 in isolation:


Runs | nlcd-soils-request-huc8.json | Future | Natural
-- | -- | -- | --
  | 1 | 6.76 | 8.25
  | 2 | 3.11 | 4.15
  | 3 | 2.77 | 4.92
  | 4 | 2.52 | 3.66
  | 5 | 3.22 | 3.73
Run 1 | Average | 3.676 | 4.942
  | 1 | 2.75 | 3.74
  | 2 | 2.41 | 3.69
  | 3 | 2.8 | 3.62
  | 4 | 2.33 | 3.61
  | 5 | 3.67 | 4.08
Run 2 | Average | 2.792 | 3.748
  | 1 | 2.42 | 4.19
  | 2 | 2.23 | 3.31
  | 3 | 2.48 | 3.45
  | 4 | 2.28 | 3.59
  | 5 | 2.82 | 3.62
Run 3 | Average | 2.446 | 3.632
  |   |   |  
  | Total Average | 2.971333333 | 4.107333333
  |   |   |  
  | Speed   up | 1.382319946 |  

So using the Futures is clearly faster. The total speed is slower when servicing multiple requests though:

![image](https://user-images.githubusercontent.com/1430060/29896792-6acd3f74-8dac-11e7-8841-5d326cce2349.png)

### Notes

I tested with `nlcd-soils-request-huc8.json` and with `nlcd-streams-request.json` and got correct results. Running many of them in parallel took longer, but everything came through in the end:

![image](https://user-images.githubusercontent.com/1430060/29896885-b2be5246-8dac-11e7-9091-efcf838ddefd.png)

Note that these times are from my local, and not within the VM, which is likely to be a little slower.

I could not reproduce the original issue in #67, wherein a single request "blocked" the machine from accepting others. If there are any recommendations for reproducing it, I can try them, otherwise I think we should proceed with what we have and make a new card if that behavior returns.

## Testing Instructions

 * Check out this branch and run `server`
 * Run one of each type of operation and ensure that the values are the same as before