### PR TITLE
Allow pixels to be treated as areas on demand

### DIFF
--- a/api/src/main/scala/Utils.scala
+++ b/api/src/main/scala/Utils.scala
@@ -8,6 +8,7 @@ import spray.json._
 import geotrellis.proj4.{CRS, ConusAlbers, LatLng, WebMercator}
 
 import geotrellis.raster._
+import geotrellis.raster.rasterize._
 import geotrellis.vector._
 import geotrellis.vector.io._
 import geotrellis.spark._
@@ -70,6 +71,26 @@ trait Utils {
       .asMultiPolygon
       .get
   }
+
+  /**
+    * Given an optional boolean value, if it is true, returns Rasterizer
+    * Options treating the raster pixels as areas. If false, returns Options
+    * treating the raster pixels as points. If not specified, return default
+    * value, which treats pixels as points.
+    *
+    * @param   pixelIsArea  An optional boolean value
+    * @return               Rasterizer Options
+    */
+  def getRasterizerOptions(pixelIsArea: Option[Boolean]): Rasterizer.Options =
+    pixelIsArea match {
+      case Some(value) =>
+        if (value)
+          Rasterizer.Options(includePartial = true, sampleType = PixelIsArea)
+        else
+          Rasterizer.Options(includePartial = true, sampleType = PixelIsPoint)
+
+      case None => Rasterizer.Options.DEFAULT
+    }
 
   /**
     * Transform the incoming GeoJSON into a [[MultiPolygon]] in the

--- a/api/src/main/scala/WebServer.scala
+++ b/api/src/main/scala/WebServer.scala
@@ -12,6 +12,7 @@ case class InputData(
   operationType: String,
   rasters: List[String],
   targetRaster: Option[String],
+  pixelIsArea: Option[Boolean],
   zoom: Int,
   polygonCRS: String,
   rasterCRS: String,
@@ -25,7 +26,7 @@ case class ResultInt(result: Map[String, Int])
 case class ResultDouble(result: Map[String, Double])
 
 object PostRequestProtocol extends DefaultJsonProtocol {
-  implicit val inputFormat = jsonFormat9(InputData)
+  implicit val inputFormat = jsonFormat10(InputData)
   implicit val postFormat = jsonFormat1(PostRequest)
   implicit val resultFormat = jsonFormat1(ResultInt)
   implicit val resultDoubleFormat = jsonFormat1(ResultDouble)


### PR DESCRIPTION
## Overview

Previously, we would always treat raster pixels as points, so if a pixel's centroid was covered in an area of interest it would be included, otherwise not. For certain rasters, where the pixel sizes are very large, for small areas of interest, no pixels are included since the areas do not cover their centroids.

By allowing the calling JSON to specify whether to treat pixels as points or areas, we allow treating certain rasters (as determined by the caller) as having pixels as areas, which will make small areas of interests run again.

Connects https://github.com/WikiWatershed/model-my-watershed/issues/2253

### Demo

![image](https://user-images.githubusercontent.com/1430060/30402717-b105bd9e-98ac-11e7-92eb-90ed5db7f676.png)

```http
$ http --print HhBb :8090/run < SquareKmPpt.json

POST /run HTTP/1.1
Accept: application/json, */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 498
Content-Type: application/json
Host: localhost:8090
User-Agent: HTTPie/0.9.9

{
    "input": {
        "operationType": "RasterGroupedAverage",
        "pixelIsArea": true,
        "polygon": [
            "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[-75.17123123758348,39.94946918388007],[-75.1595030153462,39.94946918388007],[-75.1595030153462,39.95845957765271],[-75.17123123758348,39.95845957765271],[-75.17123123758348,39.94946918388007]]]]}"
        ],
        "polygonCRS": "LatLng",
        "rasterCRS": "ConusAlbers",
        "rasters": [],
        "targetRaster": "climatology-ppt-09-epsg5070",
        "zoom": 0
    }
}

HTTP/1.1 200 OK
Content-Length: 40
Content-Type: application/json
Date: Wed, 13 Sep 2017 21:55:48 GMT
Server: akka-http/10.0.9

{
    "result": {
        "List(0)": 93.80207061767578
    }
}
```

## Testing Instructions

 * Download [SquareKmPpt.json.txt](https://github.com/WikiWatershed/mmw-geoprocessing/files/1301093/SquareKmPpt.json.txt)
 * On `develop`, POST it to the geoprocessing service. Ensure you see a 0 in the output.
 * Check out this branch. POSTing the same file should now show a real value.
 * Build and deploy the JAR to your `worker` VM. Restart the geoprocessing service.
 * Apply the following patch to your `base.py`:

```diff
diff --git a/src/mmw/mmw/settings/base.py b/src/mmw/mmw/settings/base.py
index 8349e16..409a032 100644
--- a/src/mmw/mmw/settings/base.py
+++ b/src/mmw/mmw/settings/base.py
@@ -536,6 +536,7 @@ GEOP = {
                 'polygonCRS': 'LatLng',
                 'rasters': [],
                 'targetRaster': 'climatology-ppt-{:02d}-epsg5070',
+                'pixelIsArea': True,
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedAverage',
                 'zoom': 0
@@ -547,6 +548,7 @@ GEOP = {
                 'polygonCRS': 'LatLng',
                 'rasters': [],
                 'targetRaster': 'climatology-tmean-{:02d}-epsg5070',
+                'pixelIsArea': True,
                 'rasterCRS': 'ConusAlbers',
                 'operationType': 'RasterGroupedAverage',
                 'zoom': 0
```

 * Check the MMW UI. Ensure that all the regular values are identical to that on staging.
 * Ensure climate values are populated for small areas of interest.