### PR TITLE
Improve client-side error response messages

### DIFF
--- a/api/src/main/scala/ErrorHandler.scala
+++ b/api/src/main/scala/ErrorHandler.scala
@@ -1,0 +1,42 @@
+package org.wikiwatershed.mmw.geoprocessing
+
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server._
+import StatusCodes.{BadRequest,InternalServerError}
+import Directives._
+
+sealed trait GeoprocessingException extends Exception
+case class MissingTargetRasterException() extends GeoprocessingException()
+case class MissingVectorCRSException() extends GeoprocessingException()
+case class MissingVectorException() extends GeoprocessingException()
+case class InvalidOperationException(val message: String) extends GeoprocessingException()
+case class UnknownCRSException(val crs: String) extends GeoprocessingException()
+
+trait ErrorHandler {
+  val geoprocessingExceptionHandler = ExceptionHandler {
+    case InvalidOperationException(e) => {
+      println(s"Invalid operation type: $e")
+      complete(HttpResponse(BadRequest, entity = e))
+    }
+    case MissingTargetRasterException() => {
+      println("Input error: Missing required targetRaster")
+      complete(HttpResponse(BadRequest, entity = "Missing required targetRaster"))
+    }
+    case MissingVectorCRSException() => {
+      println("Input error: Missing required vectorCRS")
+      complete(HttpResponse(BadRequest, entity = "Missing required vectorCRS"))
+    }
+    case MissingVectorException() => {
+      println(s"Input error: Missing required vector")
+      complete(HttpResponse(BadRequest, entity = "Missing required vector"))
+    }
+    case UnknownCRSException(crs) => {
+      println(s"Unknown CRS error: $crs")
+      complete(HttpResponse(BadRequest, entity = "Unknown CRS"))
+    }
+    case e: Exception => {
+      println(s"Exception: $e")
+      complete(HttpResponse(InternalServerError, entity = s"$e"))
+    }
+  }
+}

--- a/api/src/main/scala/Geoprocessing.scala
+++ b/api/src/main/scala/Geoprocessing.scala
@@ -36,14 +36,14 @@ trait Geoprocessing extends Utils {
     * @param   input  The InputData
     * @return         A histogram of results
     */
+  @throws(classOf[MissingTargetRasterException])
   def getRasterGroupedAverage(input: InputData): Future[ResultDouble] = {
     val aoi = createAOIFromInput(input)
     val futureLayers = cropRastersToAOI(input.rasters, input.zoom, aoi)
     val targetLayer = input.targetRaster match {
       case Some(targetRaster) =>
         cropSingleRasterToAOI(targetRaster, input.zoom, aoi)
-      case None =>
-        throw new Exception("Request data missing required 'targetRaster'.")
+      case None => throw new MissingTargetRasterException
     }
     val opts = getRasterizerOptions(input.pixelIsArea)
 
@@ -62,6 +62,8 @@ trait Geoprocessing extends Utils {
     * @param   input  The InputData
     * @return         A histogram of results
     */
+  @throws(classOf[MissingVectorException])
+  @throws(classOf[MissingVectorCRSException])
   def getRasterLinesJoin(input: InputData): Future[ResultInt] = {
     val aoi = createAOIFromInput(input)
     val futureLayers = cropRastersToAOI(input.rasters, input.zoom, aoi)
@@ -70,11 +72,9 @@ trait Geoprocessing extends Utils {
         input.vectorCRS match {
           case Some(crs) =>
             createMultiLineFromInput(vector, crs, input.rasterCRS)
-          case None =>
-            throw new Exception("Request data missing required 'vectorCRS'.")
+          case None => throw new MissingVectorCRSException
         }
-      case None =>
-        throw new Exception("Request data missing required 'vector'.")
+      case None => throw new MissingVectorException
     }
 
     futureLayers.map { rasterLayers =>

--- a/api/src/main/scala/Utils.scala
+++ b/api/src/main/scala/Utils.scala
@@ -153,11 +153,12 @@ trait Utils {
     * @param   crs  The key (e.g. "input.rasterCRS")
     * @return       A CRS
     */
+  @throws(classOf[UnknownCRSException])
   def getCRS(crs: String): CRS = crs match {
     case "LatLng" => LatLng
     case "WebMercator" => WebMercator
     case "ConusAlbers" => ConusAlbers
-    case s: String => throw new Exception(s"Unknown CRS: $s")
+    case s: String => throw new UnknownCRSException(s)
   }
 
   /**


### PR DESCRIPTION
## Overview

This PR adds some infrastructure to send more descriptive error messages back to the client and to catch other exceptions. I set it up by adding an ErrorHandler trait which conforms to akka-http's custom exception handling along with some case classes to match on some known exceptions we throw in the app -- for missing required fields & invalid raster ops. These are sent back as 400s; for other unforeseen exceptions we send back a 500 along with the exception message.

I also set this up to print the exception messages to the service console. I think we should configure these to log, too, but it seems like it may require some work to get `LazyLogging` to work with/supplant log4j, the latter of which is there via Spark.

We have #63 for configuring the logger.

Connects #69

## Testing Instructions
- get this branch, then `./scripts/server`
- send a variety of malformed requests to the server and verify that you get appropriate messages back and that you see the exceptions printed to the console