### PR TITLE
Subbasin: Support Streamless Children

### DIFF
--- a/api/src/main/scala/Geoprocessing.scala
+++ b/api/src/main/scala/Geoprocessing.scala
@@ -72,7 +72,7 @@ trait Geoprocessing extends Utils {
                       rasterLinesJoin(layers, Seq(lines))
                         .mapValues(_.toDouble)
                     case None =>
-                      throw new MissingStreamLinesException
+                      Map[String, Double]()
                   }
                 }
                 case None =>

--- a/api/src/main/scala/Geoprocessing.scala
+++ b/api/src/main/scala/Geoprocessing.scala
@@ -67,8 +67,13 @@ trait Geoprocessing extends Utils {
             case "RasterLinesJoin" =>
               input.streamLines match {
                 case Some(mls) => {
-                  val lines = (parseMultiLineString(mls) & shape).asMultiLine.get
-                  rasterLinesJoin(layers, Seq(lines)).mapValues(_.toDouble)
+                  (parseMultiLineString(mls) & shape).asMultiLine match {
+                    case Some(lines) =>
+                      rasterLinesJoin(layers, Seq(lines))
+                        .mapValues(_.toDouble)
+                    case None =>
+                      throw new MissingStreamLinesException
+                  }
                 }
                 case None =>
                   throw new MissingStreamLinesException


### PR DESCRIPTION
## Overview

In cases when submitting a set of shapes to the `/multi` endpoint, with a `rasterLinesJoin` operation, and `streamLines`, such that there exist shapes in the set that don't intersect with any stream lines at all, return an empty map for `nlcd_streams`. This is an edge case found in the more arid parts of the country, such as Upper Wolf HUC-8 in Texas:

![image](https://user-images.githubusercontent.com/1430060/40124757-40d714b2-58f7-11e8-91b2-3cdd0acfb5d8.png)

This PR handles these cases gracefully by returning an empty map.

Connects https://github.com/WikiWatershed/model-my-watershed/issues/2826

### Demo

Using [`failing_multi_request.json.txt`](https://github.com/WikiWatershed/mmw-geoprocessing/files/2010828/failing_multi_request.json.txt) on `develop`:

```http
$ http :8090/multi < failing_multi_request.json.txt

HTTP/1.1 500 Internal Server Error
Content-Length: 42
Content-Type: text/plain; charset=UTF-8
Date: Wed, 16 May 2018 20:56:50 GMT
Server: akka-http/10.0.9

java.util.NoSuchElementException: None.get
```

On this branch:

```bash
$ http :8090/multi < failing_multi_request.json.txt | jq . | grep nlcd_streams

    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {},
    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {},
    "nlcd_streams": {},
    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {},
    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {
    "nlcd_streams": {
```

Upper Wolf with values:

![image](https://user-images.githubusercontent.com/1430060/40144024-26651a82-592b-11e8-85ef-cd9ae1730f0c.png)

### Notes

I also tried making `rasterEmptyResults` which would gather the right keys and set them to 0, like this:

```json
  "nlcd_streams": {
    "List(11)": 0.0,
    "List(21)": 0.0,
    "List(22)": 0.0,
    "List(23)": 0.0,
    "List(24)": 0.0,
    "List(52)": 0.0,
    "List(71)": 0.0,
    "List(82)": 0.0,
    "List(95)": 0.0
  }
```

That approach looked like this:

```scala
private def rasterEmptyResult(
  rasterLayers: Seq[TileLayerCollection[SpatialKey]],
  multiPolygon: MultiPolygon
): Map[String, Double] = {
  val metadata = rasterLayers.head.metadata
  val pixelGroups: TrieMap[List[Int], Double] = TrieMap.empty

  joinCollectionLayers(rasterLayers).par
    .foreach({ case (key, tiles) =>
      val extent: Extent = metadata.mapTransform(key)
      val re: RasterExtent = RasterExtent(extent, metadata.layout.tileCols,
          metadata.layout.tileRows)

      Rasterizer.foreachCellByMultiPolygon(multiPolygon, re) { case (col, row) =>
        val pixelGroup: List[Int] = tiles.map(_.get(col, row)).toList
        pixelGroups.getOrElseUpdate(pixelGroup, 0.0)
      }
    })

  pixelGroups
    .map { case (k, v) => k.toString -> v }
    .toMap
}
```

and then replacing the return:

```diff
diff --git a/api/src/main/scala/Geoprocessing.scala b/api/src/main/scala/Geoprocessing.scala
index 4890e3a..5a1b37a 100644
--- a/api/src/main/scala/Geoprocessing.scala
+++ b/api/src/main/scala/Geoprocessing.scala
@@ -72,7 +72,7 @@ trait Geoprocessing extends Utils {
                       rasterLinesJoin(layers, Seq(lines))
                         .mapValues(_.toDouble)
                     case None =>
-                      Map[String, Double]()
+                      rasterEmptyResult(layers, shape)
                   }
                 }
                 case None =>
```

But since in other cases we return only the non-zero values:

```json
  "nlcd_streams": {
    "List(71)": 1.0
  }
```

I decided to stick to it and return an empty map for speed and simplicity. I also tested with MMW to ensure that it didn't break the app, and it doesn't seem to.

## Testing Instructions

* Download [`failing_multi_request.json.txt`](https://github.com/WikiWatershed/mmw-geoprocessing/files/2010828/failing_multi_request.json.txt).
* Run the service `./scripts/server`
* On `develop`, try submitting that to `:8090/multi` and see the error
* On this branch, try submitting that and see values