### PR TITLE
Make application settings overridable by environment variables

### DIFF
--- a/api/src/main/resources/application.conf
+++ b/api/src/main/resources/application.conf
@@ -1,15 +1,21 @@
 geoprocessing {
     port = 8090
+    port = ${?MMW_GEOPROCESSING_PORT}
     hostname = "0.0.0.0"
+    hostname = ${?MMW_GEOPROCESSING_HOST}
     s3bucket = "datahub-catalogs-us-east-1"
+    s3bucket = ${?MMW_GEOPROCESSING_BUCKET}
 }
 
 akka.http {
   server {
     idle-timeout = 121 s
+    idle-timeout = ${?MMW_GEOPROCESSING_TIMEOUT}
     request-timeout = 120 s
+    request-timeout = ${?MMW_GEOPROCESSING_TIMEOUT}
   }
   parsing {
     max-content-length = 50m
+    max-content-length = ${?MMW_GEOPROCESSING_MAXLEN}
   }
 }


### PR DESCRIPTION
## Overview

Previously these settings were baked in, and needed a new release for any changes (see #98). This makes those settings overridable with environment variables, so that changing these does not require a new release in the future. When no variables are provided, the default values are used. This was implemented following the guidance in: https://github.com/lightbend/config#optional-system-or-env-variable-overrides.

Connects https://github.com/WikiWatershed/model-my-watershed/issues/3446