### PR TITLE
Fix Max Content Length Configuration

### DIFF
--- a/api/src/main/resources/application.conf
+++ b/api/src/main/resources/application.conf
@@ -13,9 +13,9 @@ akka.http {
     idle-timeout = ${?MMW_GEOPROCESSING_TIMEOUT}
     request-timeout = 120 s
     request-timeout = ${?MMW_GEOPROCESSING_TIMEOUT}
-  }
-  parsing {
-    max-content-length = 50m
-    max-content-length = ${?MMW_GEOPROCESSING_MAXLEN}
+    parsing {
+      max-content-length = 50m
+      max-content-length = ${?MMW_GEOPROCESSING_MAXLEN}
+    }
   }
 }

--- a/api/src/main/scala/Utils.scala
+++ b/api/src/main/scala/Utils.scala
@@ -253,7 +253,7 @@ trait Utils {
     val host = config.getString("geoprocessing.hostname")
     val port = config.getString("geoprocessing.port")
     val timeout = config.getString("akka.http.server.request-timeout")
-    val maxlen = config.getString("akka.http.parsing.max-content-length")
+    val maxlen = config.getString("akka.http.server.parsing.max-content-length")
 
     println("Initializing mmw-geoprocessing with these variables:")
     println(s"MMW_GEOPROCESSING_HOST $host")


### PR DESCRIPTION
## Overview

This was changed in AkkaHttp 10.5. Without this, requests for HUC-8s were failing.

Connects https://github.com/WikiWatershed/model-my-watershed/issues/3614

### Demo

```bash
xh --print Hh :8090/multi < examples/MultiOperationRequestHiResStreams.json
```
```http
POST /multi HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate, br
Connection: keep-alive
Content-Length: 11975654
Content-Type: application/json
Host: localhost:8090
User-Agent: xh/0.22.0

HTTP/1.1 200 OK
Content-Length: 615869
Content-Type: application/json
Date: Mon, 06 May 2024 15:07:52 GMT
Server: akka-http/10.5.3
```
