### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - develop
+      - hotfix/**
+      - release/**
+      - test/**
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  compile-then-run-tests:
+    name: Compile scala, run server, run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+    
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install and configure pipenv
+        run: |
+          PYTHON_PATH=$(which python)
+          pip install pipenv
+          pipenv --python $PYTHON_PATH
+        
+      - name: Run setup script
+        run: ./scripts/setup
+
+      - name: Run test
+        run: ./scripts/citest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add GitHub Actions workflow
+
 ## 6.1.0
 
 - Updates max content length configuration for Akka Http 10.5,

--- a/scripts/citest
+++ b/scripts/citest
@@ -2,6 +2,7 @@
 set -x
 
 ./scripts/server >gh_output.txt 2>&1 &
+# Wait for server to start up before testing
 sleep 15
 ./scripts/test
 

--- a/scripts/citest
+++ b/scripts/citest
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -x
+
+./scripts/server >gh_output.txt 2>&1 &
+sleep 15
+./scripts/test
+
+# Uncomment following line to see server output in GitHub Actions
+# cat gh_output.txt


### PR DESCRIPTION
## Overview

This is the first stage of migrating CI to GitHub Actions. The goal for the CI overall is to compile scala via the update script and run the test script upon merge to develop.  Eventually this will integrate with a GitFlow release process.

Connects #97 

### Demo

- Test Branch: [GitHub Actions CI #32](https://github.com/WikiWatershed/mmw-geoprocessing/actions/runs/9085379710)
- PR Branch: [GitHub Actions CI #33](https://github.com/WikiWatershed/mmw-geoprocessing/actions/runs/9096629530)

### Notes

- The `server` script, when run on its own, will run indefinitely within CI if not ran as a background process.  Simply running the script with an `&` appended at the end will still produce output, which prevents it from running as a background process: instead, it would be a suspended background process.  Redirecting output and error to an output file (`>gh_output.txt 2>&1`) allows for it to correctly run as a background process but then raises the issue of not providing insights into possible failures.  Line 9 of the `citest` script can be uncommented in order to review the output/errors of running the `server` script.
- As AWS login is needed for the `server` script to run successfully, repository secrets for `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` have been created within the repo.  These correspond to the AWS access key and secret access key for the `github-actions` AWS user.  This information is stored in 1Password under the `DataHub GitHub User Access` entry.
- `CHANGELOG.md` will be updated when ready to merge in order to prevent possible merge conflicts.

## Testing Instructions

- [x] Create a `test/*` branch off of this branch and push up to GitHub; confirm GHA runs and completes successfully.
- [x] Create a `initials/*` branch off this branch and push up to GitHub; confirm GHA does NOT run.
